### PR TITLE
DEVOPS-652 feat: extend create scratch org to accept snapshot as extra param that allow to create an org from a template

### DIFF
--- a/cumulusci/core/config/scratch_org_config.py
+++ b/cumulusci/core/config/scratch_org_config.py
@@ -3,7 +3,6 @@ import json
 import os
 from typing import List, NoReturn, Optional
 
-
 import sarge
 
 from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
@@ -124,9 +123,6 @@ class ScratchOrgConfig(SfdxOrgConfig):
 
             self.config["org_id"] = res["orgId"]
             self.config["username"] = res["username"]
-            
-            if self.snapshot:
-                self.config["snapshot"] = self.snapshot
 
             self.config["date_created"] = datetime.datetime.utcnow()
 
@@ -161,11 +157,10 @@ class ScratchOrgConfig(SfdxOrgConfig):
                 
             # Create temporary config file
             tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+            self._tmp_config = tmp.name
             json.dump(org_config, tmp, indent=4)
             tmp.close()
             config_file = tmp.name
-            self._tmp_config = config_file
-
         args = ["-f", config_file, "-w", "120"]
         devhub_username: Optional[str] = self._choose_devhub_username()
         if devhub_username:

--- a/cumulusci/core/config/scratch_org_config.py
+++ b/cumulusci/core/config/scratch_org_config.py
@@ -149,12 +149,13 @@ class ScratchOrgConfig(SfdxOrgConfig):
         config_file = self.config_file
         self._tmp_config = None
         if self.snapshot and self.config_file:
-            # When using snapshot, remove features and edition from config
+            # When using snapshot, remove features, edition and snapshot from config
             with open(self.config_file, "r") as f:
                 org_config = json.load(f)
                 org_config.pop("features", None)
                 org_config.pop("edition", None)
-                
+                org_config.pop("snapshot", None)
+
             # Create temporary config file
             tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
             self._tmp_config = tmp.name

--- a/cumulusci/core/config/scratch_org_config.py
+++ b/cumulusci/core/config/scratch_org_config.py
@@ -158,9 +158,23 @@ class ScratchOrgConfig(SfdxOrgConfig):
             # Create temporary config file
             tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
             self._tmp_config = tmp.name
-            json.dump(org_config, tmp, indent=4)
-            tmp.close()
-            config_file = tmp.name
+
+            # Try catch error here to avoid leaving temp file around
+            try:
+                json.dump(org_config, tmp, indent=4)
+                tmp.close()
+                config_file = tmp.name
+                self._tmp_config = config_file
+            except Exception:
+                tmp_name = tmp.name
+                try:
+                    tmp.close()
+                except Exception:
+                    pass
+                if os.path.exists(tmp_name):
+                    os.remove(tmp_name)
+                raise
+
         args = ["-f", config_file, "-w", "120"]
         devhub_username: Optional[str] = self._choose_devhub_username()
         if devhub_username:

--- a/cumulusci/schema/cumulusci.jsonschema.json
+++ b/cumulusci/schema/cumulusci.jsonschema.json
@@ -435,6 +435,10 @@
                     "title": "Release",
                     "enum": ["preview", "previous"],
                     "type": "string"
+                },
+                "snapshot": {
+                    "title": "Snapshot",
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/cumulusci/utils/yaml/cumulusci_yml.py
+++ b/cumulusci/utils/yaml/cumulusci_yml.py
@@ -151,6 +151,7 @@ class ScratchOrg(CCIDictModel):
     setup_flow: str = None
     noancestors: bool = None
     release: Literal["preview", "previous"] = None
+    snapshot: str = None
 
 
 class Orgs(CCIDictModel):


### PR DESCRIPTION
## Overview

**Extend create scartch org to allow create scratch org from a salesforce snapshot**


### Related Jira Tickets
DEVOPS-652

## Changes Proposed
### Types of Changes

- add 'snapshot' options to ScratchOrg schema
- when build args for create scratch org, leverage the snapshot is specified.
- when snapshot is specified, remove 'feature' and 'edition' sessions from org_config file and used the new temp file for org creation.
- add unit test


<sup>_Indicate the type of changes your PR introduces to the project. Check the box that applies by replacing `[ ]` with `[x]` and Ensure you understand the implications of each type._</sup>

- [ ] Bug fix (non-breaking changes which fix an issue)
- [x] New feature (non-breaking changes which add functionality)
- [ ] Breaking change (changes that would cause existing functionality to not work as expected)
- [ ] Documentation update (updates to documentation, no changes to code)
- [ ] Other (please describe):

### Compliance and Security

<sup>_Ensure your changes adhere to project policies and do not introduce security vulnerabilities._</sup>

- [x] I have read and understood the [Clariti's VCS Policies](https://claritisoftware.atlassian.net/wiki/spaces/P2/pages/2756018262/CENG-3+Version+Control+System+VCS+Security+and+Compliance+Policy).
- [x] My commits are GPG-signed, adhering to project standards.
- [x] My code follows Clariti's coding standards and passes all existing lint/unit tests.
- [x] My changes do not introduce any new security issues.
- [x] I have performed a self-review to ensure the code introduces no new security vulnerabilities.
- [ ] I have addressed existing security issues in my code (if applicable).

