### PR TITLE
DEVOPS-780 feat: add GitHub Actions workflow for deploying documentation to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Deploy Docs
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "docs/**"
+            - "cumulusci/**"
+            - ".github/workflows/docs.yml"
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+    group: pages
+    cancel-in-progress: true
+
+jobs:
+    build:
+        name: Build Docs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python 3.11
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+
+            - name: Set up uv
+              uses: SFDO-Tooling/setup-uv@main
+              with:
+                  version: "0.8.4"
+                  enable-cache: true
+
+            - name: Install dependencies
+              run: uv sync --group docs
+
+            - name: Build Docs
+              run: |
+                  cd docs
+                  uv run sphinx-build -b html . ./_build/html
+
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v4.0.0
+              with:
+                  path: docs/_build/html
+
+    deploy:
+        name: Deploy to GitHub Pages
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,6 @@ on:
             - "docs/**"
             - "cumulusci/**"
             - ".github/workflows/docs.yml"
-    #temporary triigger
-    pull_request:
-        branches:
-            - main
     workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
             - "docs/**"
             - "cumulusci/**"
             - ".github/workflows/docs.yml"
+    #temporary triigger
+    pull_request:
+        branches:
+            - main
     workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated documentation build and deployment to GitHub Pages is enabled—Sphinx docs are built and published on pushes to main affecting docs paths and via manual trigger.
  * The workflow uses a pinned Python runtime, caches tooling, uploads the built site as an artifact, enforces single concurrent deployment, and surfaces the published site URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->