### PR TITLE
DEVOPS-810 fix: remove pkg_resources/PyFilesystem2 dependency

### DIFF
--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,14 +1,5 @@
 import os
 import sys
-import warnings
-
-# Suppress pkg_resources deprecation warning from PyFilesystem (fs) package
-# See: https://github.com/PyFilesystem/pyfilesystem2/issues/577
-warnings.filterwarnings(
-    "ignore",
-    message="pkg_resources is deprecated as an API",
-    category=UserWarning,
-)
 
 from simple_salesforce import api, bulk
 

--- a/cumulusci/utils/fileutils.py
+++ b/cumulusci/utils/fileutils.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from io import StringIO, TextIOWrapper
 from pathlib import Path
 from typing import IO, ContextManager, Text, Tuple, Union
-from urllib.parse import unquote as urlunquote
+from urllib.parse import urlparse
 
 import requests
 
@@ -132,10 +132,18 @@ class FSResource:
         if isinstance(resource_url_or_path, FSResource):
             self._path = resource_url_or_path._path
         elif isinstance(resource_url_or_path, str) and "://" in resource_url_or_path:
-            url_str = resource_url_or_path
-            # Strip the scheme prefix to get the path portion
-            _, path_part = url_str.split("://", 1)
-            decoded = urlunquote(path_part)
+            parsed = urlparse(resource_url_or_path)
+            if parsed.scheme != "file":
+                raise ValueError(
+                    f"Only file:// URLs are supported, got {parsed.scheme}://"
+                )
+            # For relative file URLs like file://relative/path, urlparse puts
+            # "relative" in netloc and "/path" in path. Concatenate them.
+            if parsed.netloc and parsed.netloc.lower() != "localhost":
+                path_str = parsed.netloc + parsed.path
+            else:
+                path_str = parsed.path
+            decoded = urllib.request.url2pathname(path_str)
             self._path = Path(decoded).absolute()
         else:
             self._path = Path(resource_url_or_path).absolute()
@@ -172,14 +180,10 @@ class FSResource:
         shutil.copy2(self._path, other._path)
 
     def mkdir(self, *, parents=False, exist_ok=False):
-        try:
-            self._path.mkdir(parents=parents, exist_ok=exist_ok)
-        except FileExistsError:
-            if not exist_ok:
-                raise
+        self._path.mkdir(parents=parents, exist_ok=exist_ok)
 
     def __contains__(self, other):
-        return other in str(self._path)
+        return str(other) in str(self._path)
 
     @property
     def suffix(self):

--- a/cumulusci/utils/fileutils.py
+++ b/cumulusci/utils/fileutils.py
@@ -1,14 +1,14 @@
 import os
+import shutil
 import urllib.request
 import webbrowser
 from contextlib import contextmanager
 from io import StringIO, TextIOWrapper
 from pathlib import Path
 from typing import IO, ContextManager, Text, Tuple, Union
+from urllib.parse import unquote as urlunquote
 
 import requests
-from fs import base, copy, open_fs
-from fs import path as fspath
 
 """Utilities for working with files"""
 
@@ -94,14 +94,6 @@ def load_from_source(source: DataInput) -> ContextManager[Tuple[IO[Text], Text]]
             yield f, path
 
 
-def proxy(funcname):
-    def func(self, *args, **kwargs):
-        real_func = getattr(self.fs, funcname)
-        return real_func(self.filename, *args, **kwargs)
-
-    return func
-
-
 def view_file(path):
     """Open the given file in a webbrowser or whatever
 
@@ -115,7 +107,7 @@ def view_file(path):
 
 
 class FSResource:
-    """Generalization of pathlib.Path to support S3, FTP, etc
+    """A pathlib.Path-based resource abstraction for local filesystem operations.
 
     Create them through the open_fs_resource module function or static
     function which will create a context manager that generates an FSResource.
@@ -130,7 +122,6 @@ class FSResource:
     def new(
         cls,
         resource_url_or_path: Union[str, Path, "FSResource"],
-        filesystem: base.FS = None,
     ):
         """Directly create a new FSResource from a URL or path (absolute or relative)
 
@@ -138,92 +129,61 @@ class FSResource:
         important (e.g. interactive repl experiments)."""
         self = cls.__new__(cls)
 
-        if isinstance(resource_url_or_path, str) and "://" in resource_url_or_path:
-            path_type = "url"
-        elif isinstance(resource_url_or_path, FSResource):
-            path_type = "resource"
+        if isinstance(resource_url_or_path, FSResource):
+            self._path = resource_url_or_path._path
+        elif isinstance(resource_url_or_path, str) and "://" in resource_url_or_path:
+            url_str = resource_url_or_path
+            # Strip the scheme prefix to get the path portion
+            _, path_part = url_str.split("://", 1)
+            decoded = urlunquote(path_part)
+            self._path = Path(decoded).absolute()
         else:
-            resource_url_or_path = Path(resource_url_or_path)
-            path_type = "path"
+            self._path = Path(resource_url_or_path).absolute()
 
-        if filesystem:
-            assert path_type != "resource"
-            fs = filesystem
-            filename = str(resource_url_or_path)
-        elif path_type == "resource":  # clone a resource reference
-            fs = resource_url_or_path.fs
-            filename = resource_url_or_path.filename
-        elif path_type == "path":
-            if resource_url_or_path.is_absolute():
-                if resource_url_or_path.drive:
-                    root = resource_url_or_path.drive + "/"
-                else:
-                    root = resource_url_or_path.root
-                filename = resource_url_or_path.relative_to(root).as_posix()
-            else:
-                root = Path("/").absolute()
-                filename = (
-                    (Path(".") / resource_url_or_path)
-                    .absolute()
-                    .relative_to(root)
-                    .as_posix()
-                )
-            fs = open_fs(str(root))
-        elif path_type == "url":
-            path, filename = resource_url_or_path.replace("\\", "/").rsplit("/", 1)
-            fs = open_fs(path)
-
-        self.fs = fs
-        self.filename = filename
         return self
 
-    exists = proxy("exists")
-    open = proxy("open")
-    unlink = proxy("remove")
-    rmdir = proxy("removedir")
-    removetree = proxy("removetree")
-    geturl = proxy("geturl")
+    def exists(self):
+        return os.path.exists(self._path)
+
+    def open(self, mode="r", **kw):
+        return self._path.open(mode, **kw)
+
+    def unlink(self):
+        self._path.unlink()
+
+    def rmdir(self):
+        self._path.rmdir()
+
+    def removetree(self):
+        shutil.rmtree(self._path)
 
     def getsyspath(self):
-        return Path(os.fsdecode(self.fs.getsyspath(self.filename)))
+        return self._path
+
+    def geturl(self):
+        return f"file://{urllib.request.pathname2url(str(self._path))}"
 
     def joinpath(self, other):
-        """Create a new FSResource based on an existing one
-
-        Note that calling .close() on either one (or exiting the
-        context of the original) will close the filesystem that both use.
-
-        In practice, if you use the new one within the open context
-        of the old one, you'll be fine.
-        """
-        path = fspath.join(self.filename, other)
-        return FSResource.new(self.fs.geturl(path))
+        return FSResource.new(self._path / other)
 
     def copy_to(self, other):
-        """Create a new FSResource by copying the underlying resource
-
-        Note that calling .close() on either one (or exiting the
-        context of the original) will close the filesystem that both use.
-
-        In practice, if you use the new one within the open context
-        of the old one, you'll be fine.
-        """
         if isinstance(other, (str, Path)):
             other = FSResource.new(other)
-        copy.copy_file(self.fs, self.filename, other.fs, other.filename)
+        shutil.copy2(self._path, other._path)
 
     def mkdir(self, *, parents=False, exist_ok=False):
-        if parents:
-            self.fs.makedirs(self.filename, recreate=exist_ok)
-        else:
-            self.fs.makedir(self.filename, recreate=exist_ok)
+        try:
+            self._path.mkdir(parents=parents, exist_ok=exist_ok)
+        except FileExistsError:
+            if not exist_ok:
+                raise
 
     def __contains__(self, other):
-        return other in str(self.geturl())
+        return other in str(self._path)
 
     @property
     def suffix(self):
-        return Path(self).suffix
+        return self._path.suffix
 
     def __truediv__(self, other):
         return self.joinpath(other)
@@ -232,31 +192,24 @@ class FSResource:
         return f"<FSResource {self.geturl()}>"
 
     def __str__(self):
-        rc = self.geturl()
-        if rc.startswith("file://"):
-            return rc[6:]
+        return str(self._path)
 
     def __fspath__(self):
-        return self.fs.getsyspath(self.filename)
+        return str(self._path)
 
     def close(self):
-        self.fs.close()
+        pass  # no-op: no filesystem to close
 
     @staticmethod
     @contextmanager
     def open_fs_resource(
-        resource_url_or_path: Union[str, Path, "FSResource"], filesystem: base.FS = None
+        resource_url_or_path: Union[str, Path, "FSResource"],
     ):
         """Create a context-managed FSResource
 
         Input is a URL, path (absolute or relative) or FSResource
 
-        The function should be used in a context manager. The
-        resource's underlying filesystem will be closed automatically
-        when the context ends and the data will be saved back to the
-        filesystem (local, remote, zipfile, etc.)
-
-        Think of it as a way of "mounting" a filesystem, directory or file.
+        The function should be used in a context manager.
 
         For example:
 
@@ -278,13 +231,8 @@ class FSResource:
         # yam
 
         """
-        resource = FSResource.new(resource_url_or_path, filesystem)
-        if not filesystem:
-            filesystem = resource
-        try:
-            yield resource
-        finally:
-            filesystem.close()
+        resource = FSResource.new(resource_url_or_path)
+        yield resource
 
 
 open_fs_resource = FSResource.open_fs_resource

--- a/cumulusci/utils/tests/test_fileutils.py
+++ b/cumulusci/utils/tests/test_fileutils.py
@@ -248,6 +248,10 @@ class TestFSResourceError:
         with pytest.raises(NotImplementedError):
             FSResource()
 
+    def test_non_file_url_rejected(self):
+        with pytest.raises(ValueError, match="Only file:// URLs are supported"):
+            FSResource.new("https://example.com/path")
+
 
 def test_update_tree(tmpdir):
     source_dir = Path(tmpdir.mkdir("source"))

--- a/cumulusci/utils/tests/test_fileutils.py
+++ b/cumulusci/utils/tests/test_fileutils.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import pytest
 import responses
-from fs import errors, open_fs
 
 import cumulusci
 from cumulusci.utils import fileutils, temporary_dir, update_tree
@@ -149,12 +148,6 @@ class _TestFSResourceShared:
             with open_fs_resource(resource) as resource2:
                 assert abspath in str(resource2)
 
-    def test_load_from_file_system(self):
-        abspath = os.path.abspath(self.file)
-        fs = open_fs("/")
-        with open_fs_resource(abspath, fs) as f:
-            assert abspath in str(f)
-
     def test_windows_path(self):
         abspath = "c:\\foo\\bar"
         with open_fs_resource(abspath) as f:
@@ -234,7 +227,7 @@ class TestFSResourceTempdir(_TestFSResourceShared):
             f.mkdir(parents=False, exist_ok=True)
             assert abspath.exists()
 
-            with pytest.raises(errors.DirectoryExists):
+            with pytest.raises(FileExistsError):
                 f.mkdir(parents=False, exist_ok=False)
             f.rmdir()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "cryptography",
     "python-dateutil",
     "Faker",
-    "fs",
     "github3.py",
     "jinja2",
     "keyring<=23.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -45,15 +45,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/38/e321b0e05d8cc068a594279fb7c097efb1df66231c295d482d7ad51b6473/annoy-1.17.3.tar.gz", hash = "sha256:9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15", size = 647460, upload-time = "2023-06-14T16:37:34.152Z" }
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -262,7 +253,6 @@ dependencies = [
     { name = "defusedxml" },
     { name = "docutils" },
     { name = "faker" },
-    { name = "fs" },
     { name = "github3-py" },
     { name = "jinja2" },
     { name = "keyring" },
@@ -336,7 +326,6 @@ requires-dist = [
     { name = "defusedxml" },
     { name = "docutils", specifier = "<=0.21.2" },
     { name = "faker" },
-    { name = "fs" },
     { name = "github3-py" },
     { name = "jinja2" },
     { name = "keyring", specifier = "<=23.0.1" },
@@ -636,20 +625,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/47/15b267dfe7e03dca4c4c06e7eadbd55ef4dfd368b13a0bab36d708b14366/flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b", size = 164777, upload-time = "2021-05-08T19:52:34.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/80/35a0716e5d5101e643404dabd20f07f5528a21f3ef4032d31a49c913237b/flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907", size = 73147, upload-time = "2021-05-08T19:52:32.476Z" },
-]
-
-[[package]]
-name = "fs"
-version = "2.4.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "appdirs" },
-    { name = "setuptools" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/a9/af5bfd5a92592c16cdae5c04f68187a309be8a146b528eac3c6e30edbad2/fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313", size = 187441, upload-time = "2022-05-02T09:25:54.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5c/a3d95dc1ec6cdeb032d789b552ecc76effa3557ea9186e1566df6aac18df/fs-2.4.16-py2.py3-none-any.whl", hash = "sha256:660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c", size = 135261, upload-time = "2022-05-02T09:25:52.363Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

Remove the unmaintained `fs` (PyFilesystem2) package dependency and replace it with a `pathlib.Path`-based `FSResource` implementation using only Python stdlib (`pathlib`, `shutil`, `urllib.parse`).

### Problem

The `fs` package v2.4.16 calls `pkg_resources.declare_namespace()` on import, which causes a fatal `ModuleNotFoundError` on environments where `setuptools` is not installed (e.g. GitHub Actions runners with Python 3.12+):

```
File "fs/__init__.py", line 4, in <module>
    __import__("pkg_resources").declare_namespace(__name__)
ModuleNotFoundError: No module named 'pkg_resources'
```

**CI failure**: https://github.com/ClaritiSoftware/clariti-master/actions/runs/21837631573/job/63022399964?pr=650

PyFilesystem2 is effectively unmaintained (last release May 2022). CumulusCI only uses local filesystem operations — no remote/S3/FTP features.

## Related Jira Tickets

- [DEVOPS-810](https://claritisoftware.atlassian.net/browse/DEVOPS-810)

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency removal

## Changes

| File | Change |
|------|--------|
| `cumulusci/utils/fileutils.py` | Rewrite `FSResource` to use `pathlib.Path` + stdlib instead of `fs` |
| `cumulusci/utils/tests/test_fileutils.py` | Remove `fs` imports, update `DirectoryExists` → `FileExistsError`, remove `open_fs()` test |
| `cumulusci/__init__.py` | Remove `pkg_resources` warning suppression (no longer needed) |
| `pyproject.toml` | Remove `fs` from dependencies |
| `uv.lock` | Regenerated (removes `fs` and `appdirs` transitive dep) |

## Compliance / Security Checklist

- [x] No credentials or secrets are committed
- [x] No new dependencies introduced (dependency removed)
- [x] Changes follow existing code patterns

## Testing / Documentation Checklist

- [x] All 39 FSResource tests pass on Python 3.11, 3.12, and 3.13
- [x] Full test suite passes (3265+ passed, only pre-existing failures unrelated to this change)
- [x] `import cumulusci` produces no `pkg_resources` warning
- [x] Verified fix works without `setuptools` installed (reproduces CI error before fix, passes after)
- [x] Verified `fs` package is fully removed from environment after `uv sync`

> [!NOTE]
> **CI failures are pre-existing on `main` and unrelated to this PR:**
> - **Test**: `test_annoy_post_process` (3 failures) — `annoy` native C extension segfault/crash on macOS runners. See [main branch CI](https://github.com/ClaritiSoftware/CumulusCI/actions?query=branch%3Amain).
> - **Lint**: `docs/scratch-orgs.md` markdown table/indentation reformatting by pre-commit hooks — pre-existing formatting drift on `main`.

[DEVOPS-810]: https://claritisoftware.atlassian.net/browse/DEVOPS-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified file resource handling to use direct filesystem paths and path-based operations.

* **Chores**
  * Removed the multi-filesystem library dependency.
  * Restored visibility of previously suppressed deprecation warnings.

* **API Changes**
  * Preserved public aliasing for compatibility with existing integrations.

* **Tests**
  * Updated tests for path-based behavior and added a check rejecting non-file URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->