### PR TITLE
DEVOPS-903 chore: reduce Sentry noise by filtering handled exceptions

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -14,10 +14,11 @@ import rich
 import sentry_sdk
 from rich.console import Console
 from rich.markup import escape
+from simple_salesforce.exceptions import SalesforceError
 
 import cumulusci
 from cumulusci.core.debug import set_debug_mode
-from cumulusci.core.exceptions import CumulusCIUsageError
+from cumulusci.core.exceptions import CumulusCIException, CumulusCIUsageError
 from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils.http.requests_utils import init_requests_trust
 from cumulusci.utils.logging import tee_stdout_stderr
@@ -121,6 +122,20 @@ def _set_sentry_user_context():
         sentry_sdk.set_tag("ci", ci_env)
 
 
+def _sentry_before_send(event, hint):
+    """Drop events for expected/handled exception types.
+
+    CumulusCIException (and its subclasses) are intentionally raised with
+    user-facing messages - we already tell the user what went wrong.
+    Only true surprises (bugs, unexpected third-party errors) belong in Sentry.
+    """
+    exc_info = hint.get("exc_info")
+    if exc_info and exc_info[1] is not None:
+        if isinstance(exc_info[1], _HANDLED_EXCEPTION_TYPES):
+            return None
+    return event
+
+
 def init_sentry():
     """Initialize Sentry error tracking.
 
@@ -142,6 +157,7 @@ def init_sentry():
             send_default_pii=False,
             attach_stacktrace=True,
             max_breadcrumbs=50,
+            before_send=_sentry_before_send,
         )
     except Exception as e:
         # Invalid DSN or other init error - disable telemetry gracefully
@@ -162,6 +178,59 @@ SUGGEST_ERROR_COMMAND = (
 )
 
 USAGE_ERRORS = (CumulusCIUsageError, click.UsageError)
+
+# CumulusCIException subclasses and connection errors are intentionally raised with
+# user-facing messages - we already tell the user what went wrong, Sentry gets nothing useful.
+# SalesforceError is handled separately: the user is prompted to report it (see below).
+_HANDLED_EXCEPTION_TYPES = (
+    CumulusCIException,
+    click.UsageError,
+    requests.exceptions.ConnectionError,
+)
+
+
+def _maybe_report_salesforce_error(e: SalesforceError) -> None:
+    """Optionally send a SalesforceError to Sentry after asking the user.
+
+    Behaviour is controlled by CCI_REPORT_SF_ERRORS:
+      always / 1 / true / yes  - send without prompting (good for CI scripts)
+      never  / 0 / false / no  - never send, never ask
+      (not set)                - prompt in interactive sessions; auto-send in CI
+    """
+    telemetry_on = os.environ.get("CCI_ENABLE_TELEMETRY", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not telemetry_on:
+        return
+
+    setting = os.environ.get("CCI_REPORT_SF_ERRORS", "").lower()
+
+    if setting in ("1", "true", "yes", "always"):
+        sentry_sdk.capture_exception(e)
+        return
+
+    if setting in ("0", "false", "no", "never"):
+        return
+
+    # In CI, send automatically without interrupting the pipeline
+    if _detect_ci_environment():
+        sentry_sdk.capture_exception(e)
+        return
+
+    # Interactive: ask the user
+    try:
+        console = Console(stderr=True)
+        console.print()
+        if click.confirm(
+            "Would you like to report this Salesforce error to Clariti to help improve CumulusCI?",
+            default=False,
+        ):
+            sentry_sdk.capture_exception(e)
+            console.print("[dim]Error report sent. Thank you.[/dim]")
+    except Exception:
+        pass  # stdin not available or other prompt failure - silently skip
 
 
 #
@@ -204,10 +273,11 @@ def main(args=None):
             try:
                 runtime = CliRuntime(load_keychain=False)
             except Exception as e:
-                # Capture to Sentry (for non-usage errors)
-                if not isinstance(e, USAGE_ERRORS):
-                    sentry_sdk.capture_exception(e)
                 handle_exception(e, is_error_command, tempfile_path, debug)
+                if isinstance(e, SalesforceError):
+                    _maybe_report_salesforce_error(e)
+                elif not isinstance(e, _HANDLED_EXCEPTION_TYPES):
+                    sentry_sdk.capture_exception(e)
                 sys.exit(1)
 
             runtime.check_cumulusci_version()
@@ -222,10 +292,6 @@ def main(args=None):
                 show_debug_info() if debug else console.print("\n[red bold]Aborted!")
                 sys.exit(1)
             except Exception as e:
-                # Capture to Sentry regardless of debug mode (for non-usage errors)
-                if not isinstance(e, USAGE_ERRORS):
-                    sentry_sdk.capture_exception(e)
-
                 if debug:
                     show_debug_info()
                 else:
@@ -235,6 +301,10 @@ def main(args=None):
                         tempfile_path,
                         should_show_stacktraces,
                     )
+                if isinstance(e, SalesforceError):
+                    _maybe_report_salesforce_error(e)
+                elif not isinstance(e, _HANDLED_EXCEPTION_TYPES):
+                    sentry_sdk.capture_exception(e)
                 sys.exit(1)
 
 
@@ -293,7 +363,7 @@ def show_version_info():
     latest_version = get_latest_final_version()
 
     if not latest_version > current_version:
-        console.print("You have the latest version of CumulusCI :sun_behind_cloud:\n")
+        console.print("You have the latest version of CumulusCI\n")
         display_release_notes_link(str(latest_version))
         return
 

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -434,7 +434,9 @@ def shell(runtime, script=None, python=None):
         code.interact(local=variables)
 
 
-@cli.command(name="telemetry", help="Show telemetry status and what data would be collected")
+@cli.command(
+    name="telemetry", help="Show telemetry status and what data would be collected"
+)
 def telemetry():
     """Display telemetry configuration and data that would be collected."""
     console = rich.get_console()

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -226,11 +226,12 @@ def _maybe_report_salesforce_error(e: SalesforceError) -> None:
         if click.confirm(
             "Would you like to report this Salesforce error to Clariti to help improve CumulusCI?",
             default=False,
+            err=True,
         ):
             sentry_sdk.capture_exception(e)
             console.print("[dim]Error report sent. Thank you.[/dim]")
-    except Exception:
-        pass  # stdin not available or other prompt failure - silently skip
+    except (click.Abort, EOFError, OSError):
+        pass  # stdin not available or user aborted - skip reporting quietly
 
 
 #

--- a/docs/env-var-reference.md
+++ b/docs/env-var-reference.md
@@ -114,7 +114,7 @@ in the org rather than bugs in CumulusCI itself.
 In interactive sessions, if this variable is not set, CumulusCI will ask
 after displaying the error:
 
-```
+```text
 Would you like to report this Salesforce error to Clariti to help improve CumulusCI? [y/N]:
 ```
 

--- a/docs/env-var-reference.md
+++ b/docs/env-var-reference.md
@@ -98,6 +98,33 @@ Override the environment tag sent with telemetry data. By default, CumulusCI
 automatically detects whether it's a development or production release based
 on the version string.
 
+### `CCI_REPORT_SF_ERRORS`
+
+Controls whether Salesforce API errors (`SalesforceError`) are reported to
+Sentry when telemetry is enabled. Salesforce errors are treated separately
+from other errors because they often indicate configuration or data issues
+in the org rather than bugs in CumulusCI itself.
+
+| Value | Behaviour |
+|---|---|
+| `always`, `1`, `true`, `yes` | Always send without prompting |
+| `never`, `0`, `false`, `no` | Never send, never ask |
+| *(not set)* | Prompt in interactive sessions; auto-send in CI |
+
+In interactive sessions, if this variable is not set, CumulusCI will ask
+after displaying the error:
+
+```
+Would you like to report this Salesforce error to Clariti to help improve CumulusCI? [y/N]:
+```
+
+For CI pipelines, set `CCI_REPORT_SF_ERRORS=always` to send automatically:
+
+```bash
+export CCI_ENABLE_TELEMETRY=1
+export CCI_REPORT_SF_ERRORS=always
+```
+
 ### `SENTRY_DSN`
 
 Override the default Sentry DSN endpoint. This is primarily useful for
@@ -105,15 +132,22 @@ organizations that want to route telemetry to their own Sentry instance.
 
 ### What data is collected?
 
-When telemetry is enabled, CumulusCI collects:
+When telemetry is enabled, CumulusCI automatically sends:
 
-- **Error information**: Exception type, message, and stack trace
+- **Unexpected error information**: Exception type, message, and stack trace
+  for unhandled errors (e.g. Python bugs, unexpected third-party failures)
 - **CumulusCI version**: The installed version of CumulusCI
 - **Environment**: Whether running a development or production build
 - **Anonymous user ID**: A hashed identifier based on machine characteristics
   (hostname, architecture, processor) - no personally identifiable information
 - **OS information**: Operating system name, version, and architecture
 - **CI environment**: Which CI platform is being used (if any)
+
+**Salesforce API errors** are not sent automatically - you are prompted to
+opt in each time (or can configure this with `CCI_REPORT_SF_ERRORS`).
+
+**Handled errors** (misconfiguration, missing orgs, deployment failures, etc.)
+are never sent - CumulusCI already tells you what went wrong.
 
 CumulusCI does **not** collect:
 


### PR DESCRIPTION
## Overview

Sentry was capturing a high volume of handled/expected exceptions that already display clear error messages to the user - producing noise with no actionable signal. This PR filters those out so only genuine bugs reach Sentry automatically.

Also fixes a `cci version` crash on Windows Legacy console caused by an emoji that cannot be encoded by cp1252.

## Related Jira Tickets

- [DEVOPS-903](https://claritisoftware.atlassian.net/browse/DEVOPS-903)

## Types of Changes

- [x] Bug fix
- [x] New feature / enhancement
- [ ] Breaking change
- [ ] Documentation update only

## Changes

- Added `_HANDLED_EXCEPTION_TYPES` - filters `CumulusCIException` subclasses, `click.UsageError`, and `ConnectionError` from Sentry automatically
- Added `_sentry_before_send` hook registered with the Sentry SDK as a backstop so any future `capture_exception` calls elsewhere are also covered
- Added `_maybe_report_salesforce_error` - prompts users to opt in to reporting `SalesforceError` after the error is displayed; auto-sends in CI; behaviour configurable via `CCI_REPORT_SF_ERRORS` env var (`always` / `never` / prompt)
- Reordered exception handling so the error message is shown to the user before the prompt or Sentry capture
- Removed `:sun_behind_cloud:` emoji from `show_version_info` - fixes `UnicodeEncodeError` on Windows Legacy console (cp1252)
- Documented `CCI_REPORT_SF_ERRORS` in `docs/env-var-reference.md` and updated the telemetry data collection section

## Compliance / Security Checklist

- [x] No credentials, tokens, or secrets introduced
- [x] No PII collected - telemetry remains anonymous
- [x] New env var (`CCI_REPORT_SF_ERRORS`) is opt-in and documented

## Testing / Documentation Checklist

- [x] `uv run pytest cumulusci/cli/tests/test_cci.py` - 65 passed
- [x] `docs/env-var-reference.md` updated with `CCI_REPORT_SF_ERRORS`

[DEVOPS-903]: https://claritisoftware.atlassian.net/browse/DEVOPS-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CCI_REPORT_SF_ERRORS` to optionally report Salesforce API (`SalesforceError`) details when telemetry is enabled.

* **Bug Fixes**
  * Updated CLI telemetry/error handling to avoid sending events for expected/handled exception types, and to apply the new Salesforce error reporting behavior.
  * Refined related command output formatting.

* **Documentation**
  * Updated the environment variable reference to clarify what data is collected and how `CCI_REPORT_SF_ERRORS` affects Salesforce error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->