### PR TITLE
DEVOPS-927 fix: handle redacted accessToken and password in sf CLI org display output

### DIFF
--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -12,64 +12,85 @@ logger = logging.getLogger(__name__)
 
 nl = "\n"  # fstrings can't contain backslashes
 
-# sf CLI 2.142.7+ redacts the accessToken in `sf org display --json` output,
-# replacing it with a string that starts with this prefix. When we see it we
-# transparently fetch the real token via `sf org auth show-access-token`.
-REDACTED_ACCESS_TOKEN_PREFIX = "[REDACTED]"
+# sf CLI 2.142.7+ redacts sensitive fields (access token, password) in
+# `sf org display --json` output, replacing each value with a placeholder
+# string that starts with this prefix. When we see it we transparently fetch
+# the real value via the dedicated `sf org auth show-*` command.
+REDACTED_VALUE_PREFIX = "[REDACTED]"
 
 
-def _resolve_access_token(access_token, username):
-    """Return a usable access token, resolving sf CLI redaction if needed.
+def _resolve_redacted_value(value, username, *, command, result_key, description):
+    """Resolve a value that newer sf CLI redacts in ``org display`` output.
 
-    Newer versions of the Salesforce CLI redact the ``accessToken`` field in
-    ``sf org display --json`` output. When that happens the token is replaced
-    with a placeholder string starting with ``[REDACTED]``. This helper detects
-    that placeholder and transparently fetches the real token via
-    ``sf org auth show-access-token``.
+    Newer versions of the Salesforce CLI redact sensitive fields in
+    ``sf org display --json`` output, replacing each value with a placeholder
+    starting with ``[REDACTED]``. When that placeholder is detected, fetch the
+    real value via ``command`` (whose JSON ``result`` object contains
+    ``result_key``).
 
-    For any non-redacted token (including ``None``/empty) the value is returned
+    For any non-redacted value (including ``None``/empty) the value is returned
     unchanged and no CLI call is made, keeping behavior identical on older sf
-    CLI versions.
+    CLI versions. ``description`` is a human-readable label used only in log
+    and error messages.
     """
-    if not access_token or not access_token.startswith(REDACTED_ACCESS_TOKEN_PREFIX):
-        return access_token
+    if not value or not value.startswith(REDACTED_VALUE_PREFIX):
+        return value
 
     logger.info(
-        "Salesforce CLI redacted the access token for %s; "
-        "fetching it via 'sf org auth show-access-token'",
+        "Salesforce CLI redacted the %s for %s; fetching it via 'sf %s'",
+        description,
         username,
+        command,
     )
-    p = sfdx("org auth show-access-token --no-prompt --json", username)
+    p = sfdx(command, username)
 
     if p.returncode:
-        # `show-access-token` is credential-adjacent: never log its raw
-        # stdout/stderr, which can contain token material or sensitive org
+        # These commands are credential-adjacent: never log their raw
+        # stdout/stderr, which can contain the secret itself or sensitive org
         # details. Log only the return code and keep the exception sanitized.
-        logger.error(
-            "'sf org auth show-access-token' failed (returncode %s)",
-            p.returncode,
-        )
+        logger.error("'sf %s' failed (returncode %s)", command, p.returncode)
         raise SfdxOrgException(
-            f"Unable to resolve redacted access token for {username} "
+            f"Unable to resolve redacted {description} for {username} "
             f"(returncode {p.returncode})"
         )
 
     try:
-        resolved = json.loads(p.stdout_text.read())["result"]["accessToken"]
+        resolved = json.loads(p.stdout_text.read())["result"][result_key]
     except (JSONDecodeError, KeyError, TypeError) as e:
         raise SfdxOrgException(
-            "Failed to parse access token from "
-            "'sf org auth show-access-token' output for "
+            f"Failed to parse {description} from 'sf {command}' output for "
             f"{username} ({e.__class__.__name__})"
         )
 
-    if not resolved or resolved.startswith(REDACTED_ACCESS_TOKEN_PREFIX):
+    if not resolved or resolved.startswith(REDACTED_VALUE_PREFIX):
         raise SfdxOrgException(
-            "'sf org auth show-access-token' returned an empty or still-redacted "
-            f"access token for {username}"
+            f"'sf {command}' returned an empty or still-redacted {description} "
+            f"for {username}"
         )
 
     return resolved
+
+
+def _resolve_access_token(access_token, username):
+    """Resolve a redacted access token from ``sf org display`` output."""
+    return _resolve_redacted_value(
+        access_token,
+        username,
+        command="org auth show-access-token --no-prompt --json",
+        result_key="accessToken",
+        description="access token",
+    )
+
+
+def _resolve_password(password, username):
+    """Resolve a redacted password from ``sf org display`` output."""
+    return _resolve_redacted_value(
+        password,
+        username,
+        command="org auth show-user-password --no-prompt --json",
+        result_key="password",
+        description="password",
+    )
 
 
 class SfdxOrgConfig(OrgConfig):
@@ -127,7 +148,9 @@ class SfdxOrgConfig(OrgConfig):
             "username": org_info["result"]["username"],
         }
         if org_info["result"].get("password"):
-            sfdx_info["password"] = org_info["result"]["password"]
+            sfdx_info["password"] = _resolve_password(
+                org_info["result"]["password"], self.username
+            )
         self._sfdx_info = sfdx_info
         self._sfdx_info_date = datetime.datetime.utcnow()
         self.config.update(sfdx_info)

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from json.decoder import JSONDecodeError
 
 from cumulusci.core.config import OrgConfig
@@ -7,7 +8,70 @@ from cumulusci.core.exceptions import SfdxOrgException
 from cumulusci.core.sfdx import sfdx
 from cumulusci.utils import get_git_config
 
+logger = logging.getLogger(__name__)
+
 nl = "\n"  # fstrings can't contain backslashes
+
+# sf CLI 2.142.7+ redacts the accessToken in `sf org display --json` output,
+# replacing it with a string that starts with this prefix. When we see it we
+# transparently fetch the real token via `sf org auth show-access-token`.
+REDACTED_ACCESS_TOKEN_PREFIX = "[REDACTED]"
+
+
+def _resolve_access_token(access_token, username):
+    """Return a usable access token, resolving sf CLI redaction if needed.
+
+    Newer versions of the Salesforce CLI redact the ``accessToken`` field in
+    ``sf org display --json`` output. When that happens the token is replaced
+    with a placeholder string starting with ``[REDACTED]``. This helper detects
+    that placeholder and transparently fetches the real token via
+    ``sf org auth show-access-token``.
+
+    For any non-redacted token (including ``None``/empty) the value is returned
+    unchanged and no CLI call is made, keeping behavior identical on older sf
+    CLI versions.
+    """
+    if not access_token or not access_token.startswith(REDACTED_ACCESS_TOKEN_PREFIX):
+        return access_token
+
+    logger.info(
+        "Salesforce CLI redacted the access token for %s; "
+        "fetching it via 'sf org auth show-access-token'",
+        username,
+    )
+    p = sfdx("org auth show-access-token --no-prompt --json", username)
+
+    if p.returncode:
+        stderr = p.stderr_text.read()
+        stdout = p.stdout_text.read()
+        logger.error(
+            "'sf org auth show-access-token' failed (returncode %s)\n"
+            "stderr:\n%s\nstdout:\n%s",
+            p.returncode,
+            stderr,
+            stdout,
+        )
+        raise SfdxOrgException(
+            f"Unable to resolve redacted access token for {username} "
+            f"(returncode {p.returncode})"
+        )
+
+    try:
+        resolved = json.loads(p.stdout_text.read())["result"]["accessToken"]
+    except (JSONDecodeError, KeyError, TypeError) as e:
+        raise SfdxOrgException(
+            "Failed to parse access token from "
+            "'sf org auth show-access-token' output for "
+            f"{username} ({e.__class__.__name__})"
+        )
+
+    if not resolved or resolved.startswith(REDACTED_ACCESS_TOKEN_PREFIX):
+        raise SfdxOrgException(
+            "'sf org auth show-access-token' returned an empty or still-redacted "
+            f"access token for {username}"
+        )
+
+    return resolved
 
 
 class SfdxOrgConfig(OrgConfig):
@@ -53,11 +117,14 @@ class SfdxOrgConfig(OrgConfig):
                     "Failed to parse json from output.\n  "
                     f"Exception: {e.__class__.__name__}\n  Output: {''.join(stdout_list)}"
                 )
-            org_id = org_info["result"]["accessToken"].split("!")[0]
+            access_token = _resolve_access_token(
+                org_info["result"]["accessToken"], self.username
+            )
+            org_id = access_token.split("!")[0]
 
         sfdx_info = {
             "instance_url": org_info["result"]["instanceUrl"],
-            "access_token": org_info["result"]["accessToken"],
+            "access_token": access_token,
             "org_id": org_id,
             "username": org_info["result"]["username"],
         }
@@ -180,7 +247,7 @@ class SfdxOrgConfig(OrgConfig):
             )
         else:
             info = json.loads(p.stdout_text.read())
-            return info["result"]["accessToken"]
+            return _resolve_access_token(info["result"]["accessToken"], username)
 
     def force_refresh_oauth_token(self):
         # Call org display and parse output to get instance_url and

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -62,7 +62,11 @@ def _resolve_redacted_value(value, username, *, command, result_key, description
             f"{username} ({e.__class__.__name__})"
         )
 
-    if not resolved or resolved.startswith(REDACTED_VALUE_PREFIX):
+    if (
+        not isinstance(resolved, str)
+        or not resolved
+        or resolved.startswith(REDACTED_VALUE_PREFIX)
+    ):
         raise SfdxOrgException(
             f"'sf {command}' returned an empty or still-redacted {description} "
             f"for {username}"

--- a/cumulusci/core/config/sfdx_org_config.py
+++ b/cumulusci/core/config/sfdx_org_config.py
@@ -42,14 +42,12 @@ def _resolve_access_token(access_token, username):
     p = sfdx("org auth show-access-token --no-prompt --json", username)
 
     if p.returncode:
-        stderr = p.stderr_text.read()
-        stdout = p.stdout_text.read()
+        # `show-access-token` is credential-adjacent: never log its raw
+        # stdout/stderr, which can contain token material or sensitive org
+        # details. Log only the return code and keep the exception sanitized.
         logger.error(
-            "'sf org auth show-access-token' failed (returncode %s)\n"
-            "stderr:\n%s\nstdout:\n%s",
+            "'sf org auth show-access-token' failed (returncode %s)",
             p.returncode,
-            stderr,
-            stdout,
         )
         raise SfdxOrgException(
             f"Unable to resolve redacted access token for {username} "

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -17,6 +17,7 @@ from cumulusci.core.config import (
     SfdxOrgConfig,
     UniversalConfig,
 )
+from cumulusci.core.config.sfdx_org_config import _resolve_access_token
 from cumulusci.core.exceptions import (
     NotInProject,
     ProjectConfigNotFound,
@@ -443,6 +444,63 @@ class TestScratchOrgConfig:
                 )
                 with pytest.raises(SfdxOrgException, match=exception):
                     config.get_access_token(alias="dadvisor")
+
+    def test_sfdx_info_redacted_access_token(self, Command):
+        """sfdx_info resolves a redacted token and derives a correct org_id."""
+        redacted_display = b"""{
+    "result": {
+        "instanceUrl": "url",
+        "accessToken": "[REDACTED] Use 'sf org auth show-access-token' to view",
+        "username": "username",
+        "password": "password",
+        "createdDate": "1970-01-01T00:00:00Z",
+        "expirationDate": "1970-01-08"
+    }
+}"""
+        show_token = b'{"status": 0, "result": {"accessToken": "00D000!AQEreal"}}'
+        Command.side_effect = [
+            mock.Mock(
+                stderr=io.BytesIO(b""),
+                stdout=io.BytesIO(redacted_display),
+                returncode=0,
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""),
+                stdout=io.BytesIO(show_token),
+                returncode=0,
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["access_token"] == "00D000!AQEreal"
+        assert info["org_id"] == "00D000"
+
+    def test_get_access_token_redacted(self, Command):
+        """get_access_token resolves a redacted token via the fallback command."""
+        sf = mock.Mock()
+        sf.query_all.return_value = {"records": [{"Username": "whatever@example.com"}]}
+
+        display_response = mock.Mock(returncode=0)
+        display_response.stdout_text.read.return_value = (
+            '{"result": {"accessToken": '
+            "\"[REDACTED] Use 'sf org auth show-access-token' to view\"}}"
+        )
+        show_token_response = mock.Mock(returncode=0)
+        show_token_response.stdout_text.read.return_value = (
+            '{"result": {"accessToken": "00D000!AQEreal"}}'
+        )
+        sfdx = mock.Mock(side_effect=[display_response, show_token_response])
+
+        config = ScratchOrgConfig({}, "test")
+        with mock.patch(
+            "cumulusci.core.config.org_config.OrgConfig.salesforce_client", sf
+        ):
+            with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+                access_token = config.get_access_token(alias="dadvisor")
+
+        assert access_token == "00D000!AQEreal"
 
     def test_instance_url(self, Command):
         config = ScratchOrgConfig({}, "test")
@@ -1058,3 +1116,67 @@ class TestScratchOrgConfigPytest:
             config.create_org()
 
         config._create_org_via_sfdx.assert_not_called()
+
+
+class TestResolveAccessToken:
+    """Direct unit tests for the _resolve_access_token helper."""
+
+    def _make_sfdx(self, returncode=0, stdout="", stderr=""):
+        response = mock.Mock(returncode=returncode)
+        response.stdout_text.read.return_value = stdout
+        response.stderr_text.read.return_value = stderr
+        return mock.Mock(return_value=response)
+
+    def test_non_redacted_passes_through_without_sfdx(self):
+        sfdx = mock.Mock()
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            assert _resolve_access_token("00D000!AQEreal", "user") == "00D000!AQEreal"
+        sfdx.assert_not_called()
+
+    def test_none_and_empty_pass_through_without_sfdx(self):
+        sfdx = mock.Mock()
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            assert _resolve_access_token(None, "user") is None
+            assert _resolve_access_token("", "user") == ""
+        sfdx.assert_not_called()
+
+    def test_redacted_resolves_real_token(self):
+        sfdx = self._make_sfdx(
+            stdout='{"status": 0, "result": {"accessToken": "00D000!AQEreal"}}'
+        )
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            resolved = _resolve_access_token("[REDACTED] view it", "user")
+        assert resolved == "00D000!AQEreal"
+        sfdx.assert_called_once_with(
+            "org auth show-access-token --no-prompt --json", "user"
+        )
+
+    def test_fallback_nonzero_returncode_raises(self):
+        sfdx = self._make_sfdx(returncode=1, stdout="out", stderr="err")
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="returncode 1"):
+                _resolve_access_token("[REDACTED] view it", "user")
+
+    def test_fallback_malformed_json_raises(self):
+        sfdx = self._make_sfdx(stdout="<html></html>")
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="Failed to parse access token"):
+                _resolve_access_token("[REDACTED] view it", "user")
+
+    def test_fallback_missing_key_raises(self):
+        sfdx = self._make_sfdx(stdout='{"result": {}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="Failed to parse access token"):
+                _resolve_access_token("[REDACTED] view it", "user")
+
+    def test_fallback_empty_token_raises(self):
+        sfdx = self._make_sfdx(stdout='{"result": {"accessToken": ""}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
+                _resolve_access_token("[REDACTED] view it", "user")
+
+    def test_fallback_still_redacted_token_raises(self):
+        sfdx = self._make_sfdx(stdout='{"result": {"accessToken": "[REDACTED] still"}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
+                _resolve_access_token("[REDACTED] view it", "user")

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -507,7 +507,7 @@ class TestScratchOrgConfig:
         config = SfdxOrgConfig({"username": "test", "created": True}, "test")
         info = config.sfdx_info
 
-        assert info["password"] == "s3cr3t-pw"
+        assert info["password"] == "s3cr3t-pw"  # noqa: S105
         # access token was not redacted here, so no extra CLI call for it
         assert Command.call_count == 2
 
@@ -1211,6 +1211,14 @@ class TestResolveAccessToken:
 
     def test_fallback_still_redacted_token_raises(self):
         sfdx = self._make_sfdx(stdout='{"result": {"accessToken": "[REDACTED] still"}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
+                _resolve_access_token("[REDACTED] view it", "user")
+
+    def test_fallback_non_string_token_raises(self):
+        # A malformed CLI result (non-string token) must surface as a sanitized
+        # SfdxOrgException, not an AttributeError from calling .startswith.
+        sfdx = self._make_sfdx(stdout='{"result": {"accessToken": 12345}}')
         with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
             with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
                 _resolve_access_token("[REDACTED] view it", "user")

--- a/cumulusci/core/config/tests/test_config_expensive.py
+++ b/cumulusci/core/config/tests/test_config_expensive.py
@@ -17,7 +17,10 @@ from cumulusci.core.config import (
     SfdxOrgConfig,
     UniversalConfig,
 )
-from cumulusci.core.config.sfdx_org_config import _resolve_access_token
+from cumulusci.core.config.sfdx_org_config import (
+    _resolve_access_token,
+    _resolve_password,
+)
 from cumulusci.core.exceptions import (
     NotInProject,
     ProjectConfigNotFound,
@@ -476,6 +479,37 @@ class TestScratchOrgConfig:
 
         assert info["access_token"] == "00D000!AQEreal"
         assert info["org_id"] == "00D000"
+
+    def test_sfdx_info_redacted_password(self, Command):
+        """sfdx_info resolves a redacted password via show-user-password."""
+        redacted_display = b"""{
+    "result": {
+        "instanceUrl": "url",
+        "accessToken": "00D000!AQEreal",
+        "username": "username",
+        "password": "[REDACTED] Use 'sf org auth show-user-password' to view"
+    }
+}"""
+        show_password = b'{"status": 0, "result": {"password": "s3cr3t-pw"}}'
+        Command.side_effect = [
+            mock.Mock(
+                stderr=io.BytesIO(b""),
+                stdout=io.BytesIO(redacted_display),
+                returncode=0,
+            ),
+            mock.Mock(
+                stderr=io.BytesIO(b""),
+                stdout=io.BytesIO(show_password),
+                returncode=0,
+            ),
+        ]
+
+        config = SfdxOrgConfig({"username": "test", "created": True}, "test")
+        info = config.sfdx_info
+
+        assert info["password"] == "s3cr3t-pw"
+        # access token was not redacted here, so no extra CLI call for it
+        assert Command.call_count == 2
 
     def test_get_access_token_redacted(self, Command):
         """get_access_token resolves a redacted token via the fallback command."""
@@ -1180,3 +1214,53 @@ class TestResolveAccessToken:
         with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
             with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
                 _resolve_access_token("[REDACTED] view it", "user")
+
+
+class TestResolvePassword:
+    """Direct unit tests for the _resolve_password helper."""
+
+    def _make_sfdx(self, returncode=0, stdout="", stderr=""):
+        response = mock.Mock(returncode=returncode)
+        response.stdout_text.read.return_value = stdout
+        response.stderr_text.read.return_value = stderr
+        return mock.Mock(return_value=response)
+
+    def test_non_redacted_passes_through_without_sfdx(self):
+        sfdx = mock.Mock()
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            assert _resolve_password("real-password", "user") == "real-password"
+        sfdx.assert_not_called()
+
+    def test_none_and_empty_pass_through_without_sfdx(self):
+        sfdx = mock.Mock()
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            assert _resolve_password(None, "user") is None
+            assert _resolve_password("", "user") == ""
+        sfdx.assert_not_called()
+
+    def test_redacted_resolves_real_password(self):
+        sfdx = self._make_sfdx(stdout='{"status": 0, "result": {"password": "s3cr3t"}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            resolved = _resolve_password("[REDACTED] view it", "user")
+        assert resolved == "s3cr3t"
+        sfdx.assert_called_once_with(
+            "org auth show-user-password --no-prompt --json", "user"
+        )
+
+    def test_fallback_nonzero_returncode_raises(self):
+        sfdx = self._make_sfdx(returncode=1, stdout="out", stderr="err")
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="returncode 1"):
+                _resolve_password("[REDACTED] view it", "user")
+
+    def test_fallback_malformed_json_raises(self):
+        sfdx = self._make_sfdx(stdout="<html></html>")
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="Failed to parse password"):
+                _resolve_password("[REDACTED] view it", "user")
+
+    def test_fallback_empty_password_raises(self):
+        sfdx = self._make_sfdx(stdout='{"result": {"password": ""}}')
+        with mock.patch("cumulusci.core.config.sfdx_org_config.sfdx", sfdx):
+            with pytest.raises(SfdxOrgException, match="empty or still-redacted"):
+                _resolve_password("[REDACTED] view it", "user")


### PR DESCRIPTION
## Summary

sf CLI 2.142.7 changed the behaviour of `sf org display --json` to redact sensitive fields by default. Both the `accessToken` and the `password` are returned as `[REDACTED]` placeholders:

```json
{
  "result": {
    "accessToken": "[REDACTED] Use 'sf org auth show-access-token' to view",
    "password": "[REDACTED] Use 'sf org auth show-user-password' to view",
    "instanceUrl": "https://example.scratch.my.salesforce.com"
  }
}
```

CumulusCI was caching those literal placeholder strings:

- The `accessToken` placeholder was used as a Bearer token for follow-up REST calls, so every scratch-org flow failed immediately with `INVALID_AUTH_HEADER`. The `org_id` derivation (`accessToken.split("!")[0]`) also silently produced a garbage value.
- The `password` placeholder was cached verbatim, so a scratch org with a CCI-generated password exposed `[REDACTED]...` through `config.password` / `cci org info` instead of the real password.

## Changes

- **`cumulusci/core/config/sfdx_org_config.py`**
  - New module-level helper `_resolve_redacted_value(value, username, *, command, result_key, description)`: returns the value unchanged unless it starts with the `[REDACTED]` prefix, in which case it fetches the real value via the given `sf org auth show-*` command.
  - `_resolve_access_token` and `_resolve_password` are thin wrappers over it (via `sf org auth show-access-token` / `sf org auth show-user-password`, both `--no-prompt --json`).
  - `sfdx_info`: resolves both the access token and the password before caching; `org_id` is now derived from the real token.
  - `get_access_token()`: resolves the per-user token through the same helper.
  - Emits a log line when a fallback fires (observability); keeps raw CLI output out of raised exceptions to avoid leaking credential material in CI logs; defensively raises on empty or still-redacted results.

- **`cumulusci/core/config/tests/test_config_expensive.py`**
  - `TestResolveAccessToken` / `TestResolvePassword`: direct unit tests covering every branch - non-redacted pass-through (no CLI call), `None`/empty pass-through, redacted happy-path resolution, non-zero returncode, malformed JSON, missing key, and empty / still-redacted results.
  - Integration tests through the class: `test_sfdx_info_redacted_access_token`, `test_sfdx_info_redacted_password`, and `test_get_access_token_redacted`.

## Verification

Confirmed against sf CLI **2.142.7**:

- `accessToken` and `password` are both redacted in `sf org display --json`.
- `sf org auth show-access-token --no-prompt --json` returns `{"result": {"accessToken": ...}}`.
- `sf org auth show-user-password --no-prompt --json` returns `{"result": {"password": ...}}` (matches the plugin-org schema).
- The SFDX Auth URL is absent from default `org display` output and is not read from that payload by CumulusCI, so no change is needed there.

## Behaviour

- **sf CLI < 2.142.7** (returns real values): no change in code path, no extra CLI call.
- **sf CLI >= 2.142.7** (returns `[REDACTED]`): the dedicated `show-*` command is called once per redacted field; the resolved value is cached in `_sfdx_info` as normal.

## Testing

```bash
uv run pytest cumulusci/core/config/tests/test_config_expensive.py -q
# 85 passed
```

flake8 clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Salesforce CLI output when credentials like `accessToken` (and `password`) are redacted.
  * Org details now correctly derive from a resolved access token, even when redacted in org display output.
  * Access-token and password resolution now automatically retries via fallback commands when redaction is detected, with clearer failure behavior.
* **Tests**
  * Added unit test coverage for redacted-token and redacted-password resolution, including success paths and multiple error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->