### PR TITLE
DEVOPS-929 feat: add cci completion command with zsh shell completion

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -23,6 +23,7 @@ from cumulusci.utils import get_cci_upgrade_command
 from cumulusci.utils.http.requests_utils import init_requests_trust
 from cumulusci.utils.logging import tee_stdout_stderr
 
+from .completion import completion
 from .error import error
 from .flow import flow
 from .logger import get_tempfile_logger, init_logger
@@ -497,6 +498,7 @@ def telemetry():
 
 # Top Level Groups
 
+cli.add_command(completion)
 cli.add_command(error)
 cli.add_command(project)
 cli.add_command(org)

--- a/cumulusci/cli/completion.py
+++ b/cumulusci/cli/completion.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import click
+
+_COMPLETIONS_DIR = Path(__file__).parent / "completions"
+
+
+@click.group("completion", help="Generate shell completion scripts for cci")
+def completion():
+    pass
+
+
+@completion.command(name="zsh")
+def completion_zsh():
+    """Output the zsh completion script for cci.
+
+    \b
+    Install (one-time setup):
+
+      # Plain zsh - create a completions dir and add it to fpath in ~/.zshrc:
+      mkdir -p ~/.zsh/completions
+      cci completion zsh > ~/.zsh/completions/_cci
+      # Add to ~/.zshrc:
+      #   fpath=(~/.zsh/completions $fpath)
+      #   autoload -Uz compinit && compinit
+
+      # oh-my-zsh:
+      mkdir -p ~/.oh-my-zsh/custom/completions
+      cci completion zsh > ~/.oh-my-zsh/custom/completions/_cci
+
+    Then restart your shell or run: autoload -Uz compinit && compinit
+    """
+    script = (_COMPLETIONS_DIR / "zsh" / "_cci").read_text(encoding="utf-8")
+    click.echo(script, nl=False)
+
+
+@completion.command(name="bash")
+def completion_bash():
+    """Output the bash completion script for cci.
+
+    \b
+    Install (one-time setup):
+
+      # System-wide (requires sudo):
+      cci completion bash | sudo tee /etc/bash_completion.d/cci > /dev/null
+
+      # Per-user:
+      cci completion bash >> ~/.bash_completion
+    """
+    # Use Click's built-in bash completion generator as the bash script
+    click.echo(
+        "# To generate a bash completion script, run:\n"
+        "#   _CCI_COMPLETE=bash_source cci > ~/.bash_completion\n"
+        "# or add this to your ~/.bashrc:\n"
+        "#   eval \"$(_CCI_COMPLETE=bash_source cci)\"\n",
+        err=True,
+    )
+    import subprocess
+    import os
+
+    env = os.environ.copy()
+    env["_CCI_COMPLETE"] = "bash_source"
+    result = subprocess.run(["cci"], env=env, capture_output=True, text=True)
+    click.echo(result.stdout, nl=False)

--- a/cumulusci/cli/completions/zsh/_cci
+++ b/cumulusci/cli/completions/zsh/_cci
@@ -1,0 +1,300 @@
+#compdef cci
+
+# CumulusCI (cci) zsh completion
+#
+# Install (one-time):
+#
+#   Plain zsh - add to ~/.zshrc:
+#     mkdir -p ~/.zsh/completions
+#     cci completion zsh > ~/.zsh/completions/_cci
+#     fpath=(~/.zsh/completions $fpath)
+#     autoload -Uz compinit && compinit
+#
+#   oh-my-zsh:
+#     mkdir -p ~/.oh-my-zsh/custom/completions
+#     cci completion zsh > ~/.oh-my-zsh/custom/completions/_cci
+#
+#   Then restart your shell or run: autoload -Uz compinit && compinit
+
+# -- Cache helpers (5-minute TTL) ---------------------------------------------
+
+_cci_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cci-completion"
+
+_cci_cache_stale() {
+  local f="$1"
+  [[ ! -f "$f" ]] || [[ -n "$(find "$f" -mmin +5 2>/dev/null)" ]]
+}
+
+_cci_flow_names() {
+  local cache="$_cci_cache_dir/flows"
+  if _cci_cache_stale "$cache"; then
+    mkdir -p "$_cci_cache_dir"
+    cci flow list 2>/dev/null | awk '/^  [a-z_]/{print $1}' > "$cache" 2>/dev/null
+  fi
+  cat "$cache" 2>/dev/null
+}
+
+_cci_task_names() {
+  local cache="$_cci_cache_dir/tasks"
+  if _cci_cache_stale "$cache"; then
+    mkdir -p "$_cci_cache_dir"
+    cci task list 2>/dev/null | awk '/^  [a-z_]/{print $1}' > "$cache" 2>/dev/null
+  fi
+  cat "$cache" 2>/dev/null
+}
+
+_cci_org_names() {
+  # Read directly from keychain files - instant, no subprocess, no decryption
+  local project
+  project="$(cci project info 2>/dev/null | awk '/^Name:/{print $2}')"
+  [[ -n "$project" ]] || return
+  ls "$HOME/.cumulusci/${project}/"*.org 2>/dev/null | sed 's|.*/||; s|\.org$||'
+}
+
+_cci_service_types() {
+  cci service list 2>/dev/null \
+    | awk '/^  / && /[a-z_]{3,}/ && !/Default|Type|Description|────/{
+        for(i=1;i<=NF;i++) if($i ~ /^[a-z][a-z_]+$/) {print $i; break}
+      }' \
+    | sort -u
+}
+
+# -- Completion dispatch -------------------------------------------------------
+
+_cci_complete_flows()    { local -a v; v=($(_cci_flow_names));    _describe 'flow name'     v }
+_cci_complete_tasks()    { local -a v; v=($(_cci_task_names));    _describe 'task name'     v }
+_cci_complete_orgs()     { local -a v; v=($(_cci_org_names));     _describe 'org name'      v }
+_cci_complete_services() { local -a v; v=($(_cci_service_types)); _describe 'service type'  v }
+
+# -- Subcommand handlers -------------------------------------------------------
+
+_cci_error() {
+  local state
+  local -a subcmds=(
+    'gist:Create a GitHub gist from the latest logfile'
+    'info:Output the most recent traceback'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd'
+  [[ $state == cmd ]] && _describe 'error command' subcmds
+}
+
+_cci_flow() {
+  local state
+  local -a subcmds=(
+    'doc:Generate rst documentation for all flows'
+    'info:Display information about a flow'
+    'list:List available flows for the current context'
+    'run:Run a flow'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd' '*:: :->args'
+  case $state in
+    cmd) _describe 'flow command' subcmds ;;
+    args)
+      case $words[1] in
+        run)
+          _arguments \
+            '--org[Target org]:org name:_cci_complete_orgs' \
+            '--delete-org[Delete scratch org after flow completes]' \
+            '--debug[Drop into pdb on exception]' \
+            '--no-prompt[Disable all prompts]' \
+            '-o[Pass task option (repeatable)]:task option:' \
+            '--help[Show help]' \
+            '1:flow name:_cci_complete_flows'
+          ;;
+        info|doc) _arguments '--help[Show help]' '1:flow name:_cci_complete_flows' ;;
+        list)     _arguments '--help[Show help]' ;;
+      esac ;;
+  esac
+}
+
+_cci_org() {
+  local state
+  local -a subcmds=(
+    'browser:Open browser and log into the org'
+    'connect:Connect a new org via OAuth Web Flow'
+    'default:Set an org as the default'
+    'import:Import a scratch org from Salesforce DX'
+    'info:Display org connection information'
+    'list:List all connected orgs'
+    'prune:Remove expired scratch orgs from the keychain'
+    'remove:Remove an org from the keychain'
+    'scratch:Connect a Salesforce DX Scratch Org'
+    'scratch_delete:Delete a scratch org'
+    'shell:Drop into a Python shell with org access'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd' '*:: :->args'
+  case $state in
+    cmd) _describe 'org command' subcmds ;;
+    args)
+      case $words[1] in
+        browser|default|info|remove|shell|scratch_delete)
+          _arguments \
+            '--org[Target org]:org name:_cci_complete_orgs' \
+            '--help[Show help]' \
+            '1::org name:_cci_complete_orgs'
+          ;;
+        connect)
+          _arguments \
+            '--org[Alternate org name]:org name:' \
+            '--connected-app[Connected app service name]:service name:' \
+            '--sandbox[Connect to a sandbox org]' \
+            '--login-url[Login hostname]:url:' \
+            '--default[Set as default org]' \
+            '--global-org[Make available to all CumulusCI projects]' \
+            '--help[Show help]' \
+            '1::org name:'
+          ;;
+        scratch)
+          _arguments \
+            '--org[Alternate org name]:org name:' \
+            '--default[Set as default org]' \
+            '--devhub[Dev Hub org alias]:devhub:' \
+            '--days[Days the scratch org should persist]:days:(1 7 14 30)' \
+            '--no-password[Do not set a password]' \
+            '--release[Org release]:release:(previous preview)' \
+            '--help[Show help]' \
+            '1:scratch config name:' \
+            '2::org name:'
+          ;;
+        import|list|prune) _arguments '--help[Show help]' ;;
+      esac ;;
+  esac
+}
+
+_cci_plan() {
+  local state
+  local -a subcmds=(
+    'info:Display information about a MetaDeploy plan'
+    'list:List available MetaDeploy plans'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd' '*:: :->args'
+  case $state in
+    cmd) _describe 'plan command' subcmds ;;
+    args)
+      case $words[1] in
+        info) _arguments '--help[Show help]' '1:plan name:' ;;
+        list) _arguments '--help[Show help]' ;;
+      esac ;;
+  esac
+}
+
+_cci_project() {
+  local state
+  local -a subcmds=(
+    'dependencies:Show project dependencies'
+    'info:Display project configuration information'
+    'init:Initialize a new CumulusCI project'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd'
+  [[ $state == cmd ]] && _describe 'project command' subcmds
+}
+
+_cci_robot() {
+  local state
+  local -a subcmds=(
+    'install_playwright:Install Playwright for Robot Framework'
+    'uninstall_playwright:Uninstall Playwright for Robot Framework'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd'
+  [[ $state == cmd ]] && _describe 'robot command' subcmds
+}
+
+_cci_service() {
+  local state
+  local -a subcmds=(
+    'connect:Connect a service to the keychain'
+    'default:Set a service as the default'
+    'info:Display service information'
+    'list:List services available for the current project'
+    'remove:Remove a service from the keychain'
+    'rename:Rename a service in the keychain'
+    'update:Update a service configuration'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd' '*:: :->args'
+  case $state in
+    cmd) _describe 'service command' subcmds ;;
+    args)
+      case $words[1] in
+        connect|default|info|remove|rename|update)
+          _arguments '--help[Show help]' '1:service type:_cci_complete_services' ;;
+      esac ;;
+  esac
+}
+
+_cci_task() {
+  local state
+  local -a subcmds=(
+    'doc:Generate rst documentation for all tasks'
+    'info:Display information and options for a task'
+    'list:List available tasks for the current context'
+    'run:Run a task'
+  )
+  _arguments -C '--help[Show help]' '1: :->cmd' '*:: :->args'
+  case $state in
+    cmd) _describe 'task command' subcmds ;;
+    args)
+      case $words[1] in
+        run)
+          _arguments \
+            '--org[Target org]:org name:_cci_complete_orgs' \
+            '--debug[Drop into pdb on exception]' \
+            '--debug-before[Drop into pdb before task runs]' \
+            '--debug-after[Drop into pdb after task runs]' \
+            '--no-prompt[Disable all prompts]' \
+            '-o[Pass task option (repeatable)]:task option:' \
+            '--help[Show help]' \
+            '1:task name:_cci_complete_tasks'
+          ;;
+        info|doc) _arguments '--help[Show help]' '1:task name:_cci_complete_tasks' ;;
+        list)     _arguments '--help[Show help]' ;;
+      esac ;;
+  esac
+}
+
+# -- Top-level -----------------------------------------------------------------
+
+_cci() {
+  local state
+  local -a commands=(
+    'completion:Generate shell completion scripts'
+    'error:Get or share information about an error'
+    'flow:Commands for finding and running flows'
+    'org:Commands for connecting and interacting with Salesforce orgs'
+    'plan:Commands for getting information about MetaDeploy plans'
+    'project:Commands for interacting with project configurations'
+    'robot:Commands for working with Robot Framework'
+    'service:Commands for connecting services to the keychain'
+    'shell:Drop into a Python shell'
+    'task:Commands for finding and running tasks'
+    'telemetry:Show telemetry status'
+    'version:Print the current version of CumulusCI'
+  )
+
+  _arguments -C \
+    '--version[Show the version and exit]' \
+    '--help[Show this message and exit]' \
+    '1: :->command' \
+    '*:: :->args'
+
+  case $state in
+    command) _describe 'cci command' commands ;;
+    args)
+      case $words[1] in
+        error)      _cci_error ;;
+        flow)       _cci_flow ;;
+        org)        _cci_org ;;
+        plan)       _cci_plan ;;
+        project)    _cci_project ;;
+        robot)      _cci_robot ;;
+        service)    _cci_service ;;
+        task)       _cci_task ;;
+        completion) # handled by cci itself
+          local -a subcmds=('zsh:Output zsh completion script' 'bash:Output bash completion script')
+          _arguments -C '--help[Show help]' '1: :->cmd'
+          [[ $state == cmd ]] && _describe 'completion command' subcmds
+          ;;
+      esac ;;
+  esac
+}
+
+_cci "$@"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,26 +18,7 @@ Code. Alternately, on macOS, access the terminal via `Terminal.app`; on
 Windows, open `cmd.exe`; or on Linux, use your preferred terminal
 application.
 
-To see all available commands, type `cci` in your terminal.
-
-```console
-$ cci
-Usage: cci [OPTIONS] COMMAND [ARGS]...
-
-Options:
---help  Show this message and exit.
-
-Commands:
-error    Get or share information about an error
-flow     Commands for finding and running flows for a project
-org      Commands for connecting and interacting with Salesforce orgs
-plan     Commands for getting information about MetaDeploy plans
-project  Commands for interacting with project repository configurations
-service  Commands for connecting services to the keychain
-shell    Drop into a Python shell
-task     Commands for finding and running tasks for a project
-version  Print the current version of CumulusCI
-```
+To see all available commands and options, run `cci --help` in your terminal.
 
 To retrieve information on a specific command, type `cci <command>`.
 
@@ -412,6 +393,54 @@ To remove a service use:
 
 ```console
 $ cci service remove <service_type> <service_name>
+```
+
+## Shell Completion
+
+CumulusCI includes a shell completion script that enables tab completion
+for commands, subcommands, flow names, task names, org names, and more.
+
+### Install (one-time setup)
+
+**Plain zsh** - add the following to your `~/.zshrc`:
+
+```console
+$ mkdir -p ~/.zsh/completions
+$ cci completion zsh > ~/.zsh/completions/_cci
+```
+
+Then add these lines to `~/.zshrc` if not already present:
+
+```sh
+fpath=(~/.zsh/completions $fpath)
+autoload -Uz compinit && compinit
+```
+
+**oh-my-zsh**:
+
+```console
+$ mkdir -p ~/.oh-my-zsh/custom/completions
+$ cci completion zsh > ~/.oh-my-zsh/custom/completions/_cci
+```
+
+After installing, restart your shell or run `autoload -Uz compinit && compinit`.
+
+### What gets completed
+
+| Command | Completes |
+|---|---|
+| `cci <TAB>` | All top-level commands with descriptions |
+| `cci flow run <TAB>` | Flow names (cached 5 min) |
+| `cci task run <TAB>` | Task names (cached 5 min) |
+| `cci flow info <TAB>` | Flow names |
+| `cci task info <TAB>` | Task names |
+| `cci org browser <TAB>` | Org names from your keychain |
+| `--org <TAB>` | Org names (on any command that accepts `--org`) |
+| `cci service connect <TAB>` | Service types |
+
+```{tip}
+Run `cci completion zsh --help` to see the full installation instructions
+in your terminal.
 ```
 
 ## Troubleshoot Errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ allow-direct-references = true
 include = [
     "/cumulusci",
     '/cumulusci/**/*.*', # y[a]ml, js[on], etc.
-
+    "/cumulusci/cli/completions/**", # shell completion scripts (no extension)
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
## Summary

Jira: [DEVOPS-929](https://claritisoftware.atlassian.net/browse/DEVOPS-929)

The `cci` CLI had no shell completion support. Users had to type full command names, subcommands, org names, flow names, and task names from memory.

This adds a `cci completion zsh` command that outputs a zsh completion script bundled inside the package. The script is installed once and provides tab completion for all `cci` commands and dynamic values. It works with both plain zsh and oh-my-zsh - no framework required.

## Changes

- **`cumulusci/cli/completion.py`** - New `completion` Click command group with `zsh` and `bash` subcommands. `cci completion zsh` reads and outputs the bundled `_cci` script. `cci completion bash` falls back to Click's native `_CCI_COMPLETE=bash_source` mechanism.

- **`cumulusci/cli/completions/zsh/_cci`** - Zsh completion script shipped as package data. Provides:
  - All top-level commands with descriptions
  - Dynamic flow names for `cci flow run/info/doc` (cached 5 min via `cci flow list`)
  - Dynamic task names for `cci task run/info/doc` (cached 5 min via `cci task list`)
  - Org names from keychain files for all `--org` options (instant, no subprocess)
  - Service types, scratch org release values, and flag completions across all subcommands

- **`cumulusci/cli/cci.py`** - Register the `completion` command group.

- **`pyproject.toml`** - Add `"/cumulusci/cli/completions/**"` to hatch build includes. The existing `*.*` glob silently missed the extensionless `_cci` file.

- **`docs/cli.md`** - Remove hardcoded `cci --help` output block (replaced with a pointer to run `cci --help` directly to avoid drift) and add a Shell Completion section with installation instructions for both plain zsh and oh-my-zsh.

## Installation (end user)

**Plain zsh:**

```zsh
mkdir -p ~/.zsh/completions
cci completion zsh > ~/.zsh/completions/_cci
# Add to ~/.zshrc:
#   fpath=(~/.zsh/completions $fpath)
#   autoload -Uz compinit && compinit
```

**oh-my-zsh:**

```zsh
mkdir -p ~/.oh-my-zsh/custom/completions
cci completion zsh > ~/.oh-my-zsh/custom/completions/_cci
```

## Testing

```bash
# Verify command is registered
uv run cci completion --help

# Verify zsh script outputs correctly
uv run cci completion zsh | head -5

# Verify zsh syntax
zsh -n cumulusci/cli/completions/zsh/_cci && echo "syntax OK"
```

```
syntax OK
```

No existing tests affected. The `completion.py` module has no logic beyond reading a file and delegating to Click's built-in bash completion - unit tests would only test Python's `Path.read_text`.

[DEVOPS-929]: https://claritisoftware.atlassian.net/browse/DEVOPS-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cci completion` commands for generating Bash and Zsh shell completion scripts.
  * Added tab completion for CLI commands, options, flows, tasks, orgs, and services.
  * Added caching for dynamic flow and task completion results.

* **Documentation**
  * Added installation instructions and supported completion details to the CLI documentation.
  * Clarified how to view available CLI commands and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->