### PR TITLE
DEVOPS-573 feat: add feature-branch 2GP beta strategy via annotated git tags

### DIFF
--- a/cumulusci/core/dependencies/dependencies.py
+++ b/cumulusci/core/dependencies/dependencies.py
@@ -199,6 +199,10 @@ class BaseGitHubDependency(DynamicDependency, abc.ABC):
 
     tag: Optional[str] = None
     ref: Optional[str] = None
+    # Resolve this dependency to the latest 2GP beta recorded as an annotated
+    # git tag under this feature/epic branch (used by the feature_branch_tag
+    # resolver). Overrides the run-wide feature_branch for this dependency.
+    feature_branch: Optional[str] = None
 
     @property
     @abc.abstractmethod

--- a/cumulusci/core/dependencies/resolvers.py
+++ b/cumulusci/core/dependencies/resolvers.py
@@ -202,10 +202,13 @@ class GitHubFeatureBranchTagResolver(AbstractResolver):
 
     name = "GitHub Feature Branch Tag Resolver"
 
-    def _get_feature_branch(self, context: BaseProjectConfig) -> Optional[str]:
-        """Resolve the feature branch name from context, in priority order:
-        1. an explicit `project__git__active_feature_branch` overlay, then
-        2. the current repo branch, when it is not the default branch.
+    def _get_feature_branch(
+        self, dep: DynamicDependency, context: BaseProjectConfig
+    ) -> Optional[str]:
+        """Resolve the feature branch name, in priority order:
+        1. the dependency's own `feature_branch` field (most specific), then
+        2. an explicit `project__git__active_feature_branch` overlay, then
+        3. the current repo branch, when it is not the default branch.
         Returns None when there is no feature-branch context.
 
         Any non-default branch is treated as a candidate feature/epic branch
@@ -215,6 +218,10 @@ class GitHubFeatureBranchTagResolver(AbstractResolver):
         falls through to the next resolver, so this is safe for arbitrarily
         named branches.
         """
+        dep_feature_branch = getattr(dep, "feature_branch", None)
+        if dep_feature_branch:
+            return dep_feature_branch
+
         active_feature_branch = context.lookup("project__git__active_feature_branch")
         if active_feature_branch:
             return active_feature_branch
@@ -228,13 +235,13 @@ class GitHubFeatureBranchTagResolver(AbstractResolver):
     def can_resolve(self, dep: DynamicDependency, context: BaseProjectConfig) -> bool:
         return (
             isinstance(dep, BaseGitHubDependency)
-            and self._get_feature_branch(context) is not None
+            and self._get_feature_branch(dep, context) is not None
         )
 
     def resolve(
         self, dep: BaseGitHubDependency, context: BaseProjectConfig
     ) -> Tuple[Optional[str], Optional[StaticDependency]]:
-        branch = self._get_feature_branch(context)
+        branch = self._get_feature_branch(dep, context)
         if not branch:
             return (None, None)
 

--- a/cumulusci/core/dependencies/resolvers.py
+++ b/cumulusci/core/dependencies/resolvers.py
@@ -205,16 +205,22 @@ class GitHubFeatureBranchTagResolver(AbstractResolver):
     def _get_feature_branch(self, context: BaseProjectConfig) -> Optional[str]:
         """Resolve the feature branch name from context, in priority order:
         1. an explicit `project__git__active_feature_branch` overlay, then
-        2. the current repo branch, if it starts with the feature branch prefix.
+        2. the current repo branch, when it is not the default branch.
         Returns None when there is no feature-branch context.
+
+        Any non-default branch is treated as a candidate feature/epic branch
+        (not only the `feature/` prefix), so a repo checked out on a branch such
+        as `epic/new-billing` is picked up automatically. A branch that has no
+        matching annotated tag simply yields no candidates and the strategy
+        falls through to the next resolver, so this is safe for arbitrarily
+        named branches.
         """
         active_feature_branch = context.lookup("project__git__active_feature_branch")
         if active_feature_branch:
             return active_feature_branch
 
         branch = context.repo_branch
-        prefix = context.project__git__prefix_feature
-        if branch and prefix and branch.startswith(prefix):
+        if branch and branch != context.project__git__default_branch:
             return branch
 
         return None
@@ -271,6 +277,13 @@ class GitHubFeatureBranchTagResolver(AbstractResolver):
             return (None, None)
 
         commit_sha = tag.object.sha
+
+        # Honor an explicitly unmanaged dependency: return the tagged commit
+        # with no package dependency so it deploys as unmanaged metadata,
+        # mirroring GitHubReleaseTagResolver.
+        if dep.is_unmanaged:
+            return (commit_sha, None)
+
         package_config = get_remote_project_config(repo, commit_sha)
         package_name, _ = get_package_data(package_config)
 

--- a/cumulusci/core/dependencies/resolvers.py
+++ b/cumulusci/core/dependencies/resolvers.py
@@ -30,9 +30,10 @@ from cumulusci.core.exceptions import CumulusCIException, DependencyResolutionEr
 from cumulusci.core.github import (
     find_latest_release,
     find_repo_feature_prefix,
+    get_tag_refs_for_prefix,
     get_version_id_from_commit,
 )
-from cumulusci.core.versions import PackageType
+from cumulusci.core.versions import PackageType, PackageVersionNumber
 from cumulusci.utils.git import (
     construct_release_branch_name,
     get_feature_branch_name,
@@ -55,6 +56,7 @@ class DependencyResolutionStrategy(StrEnum):
     UNLOCKED_DEFAULT_BRANCH = "unlocked_default_branch"
     BETA_RELEASE_TAG = "latest_beta"
     RELEASE_TAG = "latest_release"
+    FEATURE_BRANCH_TAG = "feature_branch_tag"
     UNMANAGED_HEAD = "unmanaged"
 
 
@@ -186,6 +188,100 @@ class GitHubBetaReleaseTagResolver(GitHubReleaseTagResolver):
 
     name = "GitHub Release Resolver (Betas)"
     include_beta = True
+
+
+class GitHubFeatureBranchTagResolver(AbstractResolver):
+    """Resolver that identifies a ref by finding the highest-versioned 2GP beta
+    recorded as an annotated git tag under the current feature branch's tag prefix.
+
+    Feature-branch betas are recorded as annotated git tags ONLY (never GitHub
+    Releases), so this resolver reads them through the git refs API. This keeps
+    them invisible to Release-based resolvers such as ``GitHubBetaReleaseTagResolver``,
+    which would otherwise surface a feature-branch build as the global "latest beta".
+    """
+
+    name = "GitHub Feature Branch Tag Resolver"
+
+    def _get_feature_branch(self, context: BaseProjectConfig) -> Optional[str]:
+        """Resolve the feature branch name from context, in priority order:
+        1. an explicit `project__git__active_feature_branch` overlay, then
+        2. the current repo branch, if it starts with the feature branch prefix.
+        Returns None when there is no feature-branch context.
+        """
+        active_feature_branch = context.lookup("project__git__active_feature_branch")
+        if active_feature_branch:
+            return active_feature_branch
+
+        branch = context.repo_branch
+        prefix = context.project__git__prefix_feature
+        if branch and prefix and branch.startswith(prefix):
+            return branch
+
+        return None
+
+    def can_resolve(self, dep: DynamicDependency, context: BaseProjectConfig) -> bool:
+        return (
+            isinstance(dep, BaseGitHubDependency)
+            and self._get_feature_branch(context) is not None
+        )
+
+    def resolve(
+        self, dep: BaseGitHubDependency, context: BaseProjectConfig
+    ) -> Tuple[Optional[str], Optional[StaticDependency]]:
+        branch = self._get_feature_branch(context)
+        if not branch:
+            return (None, None)
+
+        repo = get_repo(dep.github, context)
+        prefix = f"{branch}/"
+        tag_refs = get_tag_refs_for_prefix(repo, prefix)
+
+        # Parse each tag's version and choose the highest. PackageVersionNumber has
+        # no ordering operators, so we sort on the version-component tuple.
+        # NOTE: ADR Open Question 3 (version_base semantics) is still open. Current
+        # behavior returns the highest-versioned tag under the branch prefix
+        # regardless of the main-line base version. We intentionally do not attempt
+        # base-version matching here.
+        candidates = []
+        for tag_name, ref in tag_refs:
+            try:
+                version = PackageVersionNumber.parse(
+                    tag_name[len(prefix) :], package_type=PackageType.SECOND_GEN
+                )
+            except ValueError:
+                continue
+            candidates.append((version, tag_name, ref))
+
+        if not candidates:
+            return (None, None)
+
+        version, tag_name, ref = max(
+            candidates,
+            key=lambda c: (
+                c[0].MajorVersion,
+                c[0].MinorVersion,
+                c[0].PatchVersion,
+                int(c[0].BuildNumber),
+            ),
+        )
+
+        tag = repo.tag(ref.object.sha)
+        version_id, package_type = get_package_details_from_tag(tag)
+        if not version_id:
+            return (None, None)
+
+        commit_sha = tag.object.sha
+        package_config = get_remote_project_config(repo, commit_sha)
+        package_name, _ = get_package_data(package_config)
+
+        return (
+            commit_sha,
+            PackageVersionIdDependency(
+                version_id=version_id,
+                version_number=version.format(),
+                package_name=package_name,
+            ),
+        )
 
 
 class GitHubUnmanagedHeadResolver(AbstractResolver):
@@ -501,6 +597,7 @@ RESOLVER_CLASSES = {
     DependencyResolutionStrategy.COMMIT_STATUS_DEFAULT_BRANCH: GitHubDefaultBranch2GPResolver,
     DependencyResolutionStrategy.BETA_RELEASE_TAG: GitHubBetaReleaseTagResolver,
     DependencyResolutionStrategy.RELEASE_TAG: GitHubReleaseTagResolver,
+    DependencyResolutionStrategy.FEATURE_BRANCH_TAG: GitHubFeatureBranchTagResolver,
     DependencyResolutionStrategy.UNMANAGED_HEAD: GitHubUnmanagedHeadResolver,
     DependencyResolutionStrategy.UNLOCKED_EXACT_BRANCH: GitHubExactMatchUnlockedCommitStatusResolver,
     DependencyResolutionStrategy.UNLOCKED_RELEASE_BRANCH: GitHubReleaseBranchUnlockedResolver,

--- a/cumulusci/core/dependencies/tests/test_resolvers.py
+++ b/cumulusci/core/dependencies/tests/test_resolvers.py
@@ -22,6 +22,7 @@ from cumulusci.core.dependencies.resolvers import (
     GitHubBetaReleaseTagResolver,
     GitHubDefaultBranch2GPResolver,
     GitHubExactMatch2GPResolver,
+    GitHubFeatureBranchTagResolver,
     GitHubReleaseBranchCommitStatusResolver,
     GitHubReleaseTagResolver,
     GitHubTagResolver,
@@ -315,6 +316,131 @@ version_id: 04t000000000000"""
 
         assert resolver.can_resolve(dep, project_config)
         assert resolver.resolve(dep, project_config) == (None, None)
+
+
+class TestGitHubFeatureBranchTagResolver:
+    def _make_context(self, active=None, repo_branch=None, prefix="feature/"):
+        context = mock.Mock()
+
+        def lookup(name, *args, **kwargs):
+            if name == "project__git__active_feature_branch":
+                return active
+            return None
+
+        context.lookup.side_effect = lookup
+        context.repo_branch = repo_branch
+        context.project__git__prefix_feature = prefix
+        return context
+
+    def _dep(self):
+        return GitHubDynamicDependency(
+            github="https://github.com/SFDO-Tooling/TwoGPRepo"
+        )
+
+    def test_can_resolve__no_feature_branch(self):
+        # On `main`, with no active feature branch overlay, the resolver
+        # short-circuits cleanly.
+        context = self._make_context(active=None, repo_branch="main")
+        resolver = GitHubFeatureBranchTagResolver()
+        assert not resolver.can_resolve(self._dep(), context)
+
+    def test_can_resolve__repo_branch_with_prefix(self):
+        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.can_resolve(self._dep(), context)
+
+    def test_can_resolve__active_feature_branch_lookup(self):
+        # The active_feature_branch overlay takes priority even when repo_branch
+        # is not a feature branch.
+        context = self._make_context(active="feature/DEVOPS-999", repo_branch="main")
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.can_resolve(self._dep(), context)
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_package_data")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_remote_project_config")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__highest_version(
+        self, get_repo, get_tag_refs, get_remote_config, get_package_data
+    ):
+        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        repo = mock.Mock()
+        get_repo.return_value = repo
+
+        ref1 = mock.Mock()
+        ref1.object.sha = "sha1"
+        ref2 = mock.Mock()
+        ref2.object.sha = "sha2"
+        ref10 = mock.Mock()
+        ref10.object.sha = "sha10"
+        # Build 10 must beat build 2 (integer sort, not string).
+        get_tag_refs.return_value = [
+            ("feature/DEVOPS-573/2.5.0.1", ref1),
+            ("feature/DEVOPS-573/2.5.0.2", ref2),
+            ("feature/DEVOPS-573/2.5.0.10", ref10),
+        ]
+
+        tag = mock.Mock()
+        tag.object.sha = "commit_sha_10"
+        tag.message = "version_id: 04t000000000010\n\npackage_type: 2GP"
+        repo.tag.return_value = tag
+
+        get_remote_config.return_value = mock.Mock()
+        get_package_data.return_value = ("MyPackage", "ns")
+
+        resolver = GitHubFeatureBranchTagResolver()
+        result = resolver.resolve(self._dep(), context)
+
+        # Winning tag is the build-10 tag.
+        repo.tag.assert_called_once_with("sha10")
+        assert result == (
+            "commit_sha_10",
+            PackageVersionIdDependency(
+                version_id="04t000000000010",
+                version_number="2.5.0.10",
+                package_name="MyPackage",
+            ),
+        )
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__uses_active_feature_branch_prefix(self, get_repo, get_tag_refs):
+        context = self._make_context(active="feature/DEVOPS-999", repo_branch="main")
+        get_repo.return_value = mock.Mock()
+        get_tag_refs.return_value = []
+
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.resolve(self._dep(), context) == (None, None)
+        get_tag_refs.assert_called_once_with(
+            get_repo.return_value, "feature/DEVOPS-999/"
+        )
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__no_tags(self, get_repo, get_tag_refs):
+        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        get_repo.return_value = mock.Mock()
+        get_tag_refs.return_value = []
+
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.resolve(self._dep(), context) == (None, None)
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__no_version_id_in_tag(self, get_repo, get_tag_refs):
+        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        repo = mock.Mock()
+        get_repo.return_value = repo
+        ref = mock.Mock()
+        ref.object.sha = "sha1"
+        get_tag_refs.return_value = [("feature/DEVOPS-573/2.5.0.1", ref)]
+        tag = mock.Mock()
+        tag.object.sha = "commit_sha"
+        tag.message = "package_type: 2GP"  # no version_id
+        repo.tag.return_value = tag
+
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.resolve(self._dep(), context) == (None, None)
 
 
 class TestGitHubUnmanagedHeadResolver:

--- a/cumulusci/core/dependencies/tests/test_resolvers.py
+++ b/cumulusci/core/dependencies/tests/test_resolvers.py
@@ -319,7 +319,9 @@ version_id: 04t000000000000"""
 
 
 class TestGitHubFeatureBranchTagResolver:
-    def _make_context(self, active=None, repo_branch=None, prefix="feature/"):
+    def _make_context(
+        self, active=None, repo_branch=None, default_branch="main", prefix="feature/"
+    ):
         context = mock.Mock()
 
         def lookup(name, *args, **kwargs):
@@ -329,30 +331,39 @@ class TestGitHubFeatureBranchTagResolver:
 
         context.lookup.side_effect = lookup
         context.repo_branch = repo_branch
+        context.project__git__default_branch = default_branch
         context.project__git__prefix_feature = prefix
         return context
 
-    def _dep(self):
+    def _dep(self, unmanaged=False):
         return GitHubDynamicDependency(
-            github="https://github.com/SFDO-Tooling/TwoGPRepo"
+            github="https://github.com/SFDO-Tooling/TwoGPRepo",
+            unmanaged=unmanaged,
         )
 
     def test_can_resolve__no_feature_branch(self):
-        # On `main`, with no active feature branch overlay, the resolver
-        # short-circuits cleanly.
+        # On the default branch, with no active feature branch overlay, the
+        # resolver short-circuits cleanly.
         context = self._make_context(active=None, repo_branch="main")
         resolver = GitHubFeatureBranchTagResolver()
         assert not resolver.can_resolve(self._dep(), context)
 
     def test_can_resolve__repo_branch_with_prefix(self):
-        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        context = self._make_context(active=None, repo_branch="feature/widget")
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.can_resolve(self._dep(), context)
+
+    def test_can_resolve__arbitrary_non_default_branch(self):
+        # Any non-default branch (not only the feature/ prefix) is treated as a
+        # candidate feature/epic branch, so an epic branch is picked up.
+        context = self._make_context(active=None, repo_branch="epic/new-billing")
         resolver = GitHubFeatureBranchTagResolver()
         assert resolver.can_resolve(self._dep(), context)
 
     def test_can_resolve__active_feature_branch_lookup(self):
         # The active_feature_branch overlay takes priority even when repo_branch
-        # is not a feature branch.
-        context = self._make_context(active="feature/DEVOPS-999", repo_branch="main")
+        # is the default branch.
+        context = self._make_context(active="feature/gadget", repo_branch="main")
         resolver = GitHubFeatureBranchTagResolver()
         assert resolver.can_resolve(self._dep(), context)
 
@@ -363,7 +374,7 @@ class TestGitHubFeatureBranchTagResolver:
     def test_resolve__highest_version(
         self, get_repo, get_tag_refs, get_remote_config, get_package_data
     ):
-        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        context = self._make_context(active=None, repo_branch="feature/widget")
         repo = mock.Mock()
         get_repo.return_value = repo
 
@@ -375,9 +386,9 @@ class TestGitHubFeatureBranchTagResolver:
         ref10.object.sha = "sha10"
         # Build 10 must beat build 2 (integer sort, not string).
         get_tag_refs.return_value = [
-            ("feature/DEVOPS-573/2.5.0.1", ref1),
-            ("feature/DEVOPS-573/2.5.0.2", ref2),
-            ("feature/DEVOPS-573/2.5.0.10", ref10),
+            ("feature/widget/2.5.0.1", ref1),
+            ("feature/widget/2.5.0.2", ref2),
+            ("feature/widget/2.5.0.10", ref10),
         ]
 
         tag = mock.Mock()
@@ -405,20 +416,45 @@ class TestGitHubFeatureBranchTagResolver:
     @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
     def test_resolve__uses_active_feature_branch_prefix(self, get_repo, get_tag_refs):
-        context = self._make_context(active="feature/DEVOPS-999", repo_branch="main")
+        context = self._make_context(active="feature/gadget", repo_branch="main")
         get_repo.return_value = mock.Mock()
         get_tag_refs.return_value = []
 
         resolver = GitHubFeatureBranchTagResolver()
         assert resolver.resolve(self._dep(), context) == (None, None)
-        get_tag_refs.assert_called_once_with(
-            get_repo.return_value, "feature/DEVOPS-999/"
-        )
+        get_tag_refs.assert_called_once_with(get_repo.return_value, "feature/gadget/")
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_package_data")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_remote_project_config")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__unmanaged_returns_no_package_dependency(
+        self, get_repo, get_tag_refs, get_remote_config, get_package_data
+    ):
+        # An explicitly unmanaged dependency resolves to the tagged commit with
+        # no package dependency, so it deploys as unmanaged metadata.
+        context = self._make_context(active=None, repo_branch="feature/widget")
+        repo = mock.Mock()
+        get_repo.return_value = repo
+        ref = mock.Mock()
+        ref.object.sha = "sha1"
+        get_tag_refs.return_value = [("feature/widget/2.5.0.1", ref)]
+        tag = mock.Mock()
+        tag.object.sha = "commit_sha"
+        tag.message = "version_id: 04t000000000001\n\npackage_type: 2GP"
+        repo.tag.return_value = tag
+
+        resolver = GitHubFeatureBranchTagResolver()
+        result = resolver.resolve(self._dep(unmanaged=True), context)
+
+        assert result == ("commit_sha", None)
+        # The package config is never fetched when installing unmanaged.
+        get_remote_config.assert_not_called()
 
     @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
     def test_resolve__no_tags(self, get_repo, get_tag_refs):
-        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        context = self._make_context(active=None, repo_branch="feature/widget")
         get_repo.return_value = mock.Mock()
         get_tag_refs.return_value = []
 
@@ -428,12 +464,12 @@ class TestGitHubFeatureBranchTagResolver:
     @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
     def test_resolve__no_version_id_in_tag(self, get_repo, get_tag_refs):
-        context = self._make_context(active=None, repo_branch="feature/DEVOPS-573")
+        context = self._make_context(active=None, repo_branch="feature/widget")
         repo = mock.Mock()
         get_repo.return_value = repo
         ref = mock.Mock()
         ref.object.sha = "sha1"
-        get_tag_refs.return_value = [("feature/DEVOPS-573/2.5.0.1", ref)]
+        get_tag_refs.return_value = [("feature/widget/2.5.0.1", ref)]
         tag = mock.Mock()
         tag.object.sha = "commit_sha"
         tag.message = "package_type: 2GP"  # no version_id

--- a/cumulusci/core/dependencies/tests/test_resolvers.py
+++ b/cumulusci/core/dependencies/tests/test_resolvers.py
@@ -367,6 +367,27 @@ class TestGitHubFeatureBranchTagResolver:
         resolver = GitHubFeatureBranchTagResolver()
         assert resolver.can_resolve(self._dep(), context)
 
+    def test_can_resolve__per_dependency_feature_branch(self):
+        # A per-dependency feature_branch resolves even on the default branch
+        # with no overlay.
+        context = self._make_context(active=None, repo_branch="main")
+        dep = GitHubDynamicDependency(
+            github="https://github.com/SFDO-Tooling/TwoGPRepo",
+            feature_branch="epic/new-billing",
+        )
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.can_resolve(dep, context)
+
+    def test_get_feature_branch__per_dependency_overrides_context(self):
+        # The dependency's own feature_branch wins over the run-wide overlay.
+        context = self._make_context(active="feature/gadget", repo_branch="main")
+        dep = GitHubDynamicDependency(
+            github="https://github.com/SFDO-Tooling/TwoGPRepo",
+            feature_branch="epic/new-billing",
+        )
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver._get_feature_branch(dep, context) == "epic/new-billing"
+
     @mock.patch("cumulusci.core.dependencies.resolvers.get_package_data")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_remote_project_config")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
@@ -423,6 +444,25 @@ class TestGitHubFeatureBranchTagResolver:
         resolver = GitHubFeatureBranchTagResolver()
         assert resolver.resolve(self._dep(), context) == (None, None)
         get_tag_refs.assert_called_once_with(get_repo.return_value, "feature/gadget/")
+
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_tag_refs_for_prefix")
+    @mock.patch("cumulusci.core.dependencies.resolvers.get_repo")
+    def test_resolve__per_dependency_feature_branch_prefix(
+        self, get_repo, get_tag_refs
+    ):
+        # The dependency's own feature_branch drives the tag prefix, even when a
+        # different run-wide branch is active.
+        context = self._make_context(active="feature/gadget", repo_branch="main")
+        get_repo.return_value = mock.Mock()
+        get_tag_refs.return_value = []
+        dep = GitHubDynamicDependency(
+            github="https://github.com/SFDO-Tooling/TwoGPRepo",
+            feature_branch="epic/new-billing",
+        )
+
+        resolver = GitHubFeatureBranchTagResolver()
+        assert resolver.resolve(dep, context) == (None, None)
+        get_tag_refs.assert_called_once_with(get_repo.return_value, "epic/new-billing/")
 
     @mock.patch("cumulusci.core.dependencies.resolvers.get_package_data")
     @mock.patch("cumulusci.core.dependencies.resolvers.get_remote_project_config")

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -5,7 +5,7 @@ import re
 import time
 import webbrowser
 from string import Template
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import github3
@@ -442,6 +442,36 @@ def get_version_id_from_tag(repo: Repository, tag_name: str) -> str:
             return version_id
 
     raise DependencyLookupError(f"Could not find version_id for tag {tag_name}")
+
+
+def get_tag_refs_for_prefix(
+    repo: Repository, prefix: str
+) -> List[Tuple[str, Reference]]:
+    """List annotated git tag references whose tag name starts with `prefix`.
+
+    This uses the git refs API (``GET /repos/{owner}/{repo}/git/refs/tags/{prefix}``)
+    and NEVER the GitHub Releases API, so feature-branch tags remain invisible to
+    Release-based resolvers such as ``GitHubBetaReleaseTagResolver``.
+
+    Returns a list of ``(tag_name, Reference)`` tuples. Version selection is left to
+    the caller so it can sort on the parsed version components.
+    """
+    # In github3.py v4.0.1, `Repository.refs(subspace='', ...)` takes the subspace
+    # as its first positional arg; passing `type=` as a kwarg would fail.
+    # `refs()` returns a lazy iterator, so a missing prefix raises NotFoundError
+    # during iteration rather than at the call.
+    results = []
+    try:
+        for ref in repo.refs(f"tags/{prefix}"):
+            tag_name = ref.ref
+            if tag_name.startswith("refs/tags/"):
+                tag_name = tag_name[len("refs/tags/") :]
+            if tag_name.startswith(prefix):
+                results.append((tag_name, ref))
+    except github3.exceptions.NotFoundError:
+        return []
+
+    return results
 
 
 def format_github3_exception(

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -545,7 +545,7 @@ class TestGithub(GithubApiTestMixin):
     @responses.activate
     def test_get_tag_refs_for_prefix(self, repo):
         self.init_github()
-        prefix = "feature/DEVOPS-573/"
+        prefix = "feature/widget/"
         responses.add(
             "GET",
             f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/{prefix}",
@@ -558,15 +558,15 @@ class TestGithub(GithubApiTestMixin):
         results = get_tag_refs_for_prefix(repo, prefix)
         tag_names = [name for name, ref in results]
         assert tag_names == [
-            "feature/DEVOPS-573/2.5.0.1",
-            "feature/DEVOPS-573/2.5.0.2",
+            "feature/widget/2.5.0.1",
+            "feature/widget/2.5.0.2",
         ]
         assert results[0][1].object.sha == "sha1"
 
     @responses.activate
     def test_get_tag_refs_for_prefix__none(self, repo):
         self.init_github()
-        prefix = "feature/DEVOPS-573/"
+        prefix = "feature/widget/"
         responses.add(
             "GET",
             f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/{prefix}",

--- a/cumulusci/core/tests/test_github.py
+++ b/cumulusci/core/tests/test_github.py
@@ -55,6 +55,7 @@ from cumulusci.core.github import (
     get_ref_for_tag,
     get_sso_disabled_orgs,
     get_tag_by_name,
+    get_tag_refs_for_prefix,
     get_version_id_from_tag,
     is_label_on_pull_request,
     is_pull_request_merged,
@@ -540,6 +541,38 @@ class TestGithub(GithubApiTestMixin):
         )
         version_id = get_version_id_from_tag(repo, "test-tag-name")
         assert version_id == "04t000000000000"
+
+    @responses.activate
+    def test_get_tag_refs_for_prefix(self, repo):
+        self.init_github()
+        prefix = "feature/DEVOPS-573/"
+        responses.add(
+            "GET",
+            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/{prefix}",
+            json=[
+                self._get_expected_tag_ref(f"{prefix}2.5.0.1", "sha1"),
+                self._get_expected_tag_ref(f"{prefix}2.5.0.2", "sha2"),
+            ],
+            status=200,
+        )
+        results = get_tag_refs_for_prefix(repo, prefix)
+        tag_names = [name for name, ref in results]
+        assert tag_names == [
+            "feature/DEVOPS-573/2.5.0.1",
+            "feature/DEVOPS-573/2.5.0.2",
+        ]
+        assert results[0][1].object.sha == "sha1"
+
+    @responses.activate
+    def test_get_tag_refs_for_prefix__none(self, repo):
+        self.init_github()
+        prefix = "feature/DEVOPS-573/"
+        responses.add(
+            "GET",
+            f"https://api.github.com/repos/TestOwner/TestRepo/git/refs/tags/{prefix}",
+            status=404,
+        )
+        assert get_tag_refs_for_prefix(repo, prefix) == []
 
     @responses.activate
     def test_get_version_id_from_tag__dependency_error(self, repo):

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -383,6 +383,10 @@ tasks:
         description: Creates a Github release for a given managed package version number
         class_path: cumulusci.tasks.github.CreateRelease
         group: GitHub
+    create_feature_branch_tag:
+        description: Records a feature-branch 2GP beta as an annotated git tag only (no GitHub Release)
+        class_path: cumulusci.tasks.github.feature_branch_tag.CreateFeatureBranchTag
+        group: GitHub
     gather_release_notes:
         description: Generates release notes by getting the latest release of each repository
         class_path: cumulusci.tasks.release_notes.task.AllGithubReleaseNotes
@@ -1019,6 +1023,26 @@ flows:
                 flow: config_dev
             4:
                 task: snapshot_changes
+    feature_org:
+        group: Org Setup
+        description: >-
+            Set up a scratch org (the `feature` org) seeded with the latest 2GP beta
+            built from the current feature branch. Uses the `feature_branch` resolution
+            strategy; when no feature branch is in context the feature_branch_tag
+            resolver short-circuits and the stack falls through to latest_beta, so this
+            flow is always safe to run.
+        steps:
+            1:
+                flow: dependencies
+                options:
+                    update_dependencies:
+                        resolution_strategy: feature_branch
+            2:
+                flow: deploy_unmanaged
+            3:
+                flow: config_dev
+            4:
+                task: snapshot_changes
     qa_org:
         group: Org Setup
         description: Set up an org as a QA environment for unmanaged metadata
@@ -1553,6 +1577,12 @@ project:
                 - unmanaged
             latest_release:
                 - tag
+                - latest_release
+                - unmanaged
+            feature_branch:
+                - tag
+                - feature_branch_tag
+                - latest_beta
                 - latest_release
                 - unmanaged
     dependencies:

--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -150,6 +150,10 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "description": "If True, create unlocked packages for unpackaged metadata in this project and dependencies. "
             "Defaults to False."
         },
+        "branch": {
+            "description": "Branch to scope the 2GP build counter (the Package2VersionCreateRequest Branch field). "
+            "Optional; defaults to the project's current repo branch."
+        },
     }
 
     def _init_options(self, kwargs):
@@ -352,6 +356,11 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         skip_validation: bool = False,
         dependencies: list = None,
     ):
+        # Resolve the branch used to scope the 2GP build counter. Salesforce
+        # scopes the build counter independently per (Package2, M.M.P, Branch),
+        # so feature-branch builds get their own sequence.
+        branch_value = self.options.get("branch") or self.project_config.repo_branch
+
         # Prepare the VersionInfo file
         version_bytes = io.BytesIO()
         version_info = zipfile.ZipFile(version_bytes, "w", zipfile.ZIP_DEFLATED)
@@ -361,7 +370,14 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             version_info.writestr("package.zip", package_zip_builder.as_bytes())
 
             if not self.options["force_upload"]:
-                # Check for an existing package with the same contents
+                # Check for an existing package with the same contents.
+                # When a branch is set, scope the content-dedup lookup to that
+                # branch so an identical-content request created on a different
+                # branch is not reused (which would defeat per-branch counter
+                # isolation).
+                branch_filter = (
+                    f"AND Branch = '{branch_value}' " if branch_value else ""
+                )
                 res = self.tooling.query(
                     "SELECT Id "
                     "FROM Package2VersionCreateRequest "
@@ -369,6 +385,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
                     "AND Status != 'Error' "
                     f"AND SkipValidation = {str(skip_validation)} "
                     f"AND Tag = 'hash:{package_hash}' "
+                    f"{branch_filter}"
                     "ORDER BY CreatedDate DESC"
                 )
                 if res["size"] > 0:
@@ -457,6 +474,8 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "VersionInfo": version_info,
             "CalculateCodeCoverage": not skip_validation,
         }
+        if branch_value:
+            request["Branch"] = branch_value
 
         install_key = self.options.get("install_key")
         if install_key:

--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -152,7 +152,8 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         },
         "branch": {
             "description": "Branch to scope the 2GP build counter (the Package2VersionCreateRequest Branch field). "
-            "Optional; defaults to the project's current repo branch."
+            "Optional; when omitted the Branch field is not set and the build counter is unscoped, "
+            "matching the default behavior. Set this to give a feature/epic branch its own build sequence."
         },
     }
 
@@ -358,8 +359,10 @@ class CreatePackageVersion(BaseSalesforceApiTask):
     ):
         # Resolve the branch used to scope the 2GP build counter. Salesforce
         # scopes the build counter independently per (Package2, M.M.P, Branch),
-        # so feature-branch builds get their own sequence.
-        branch_value = self.options.get("branch") or self.project_config.repo_branch
+        # so feature-branch builds get their own sequence. This is opt-in: the
+        # Branch field is only set when the branch option is explicitly passed,
+        # so default builds behave exactly as before (no Branch, unscoped).
+        branch_value = self.options.get("branch")
 
         # Prepare the VersionInfo file
         version_bytes = io.BytesIO()

--- a/cumulusci/tasks/github/feature_branch_tag.py
+++ b/cumulusci/tasks/github/feature_branch_tag.py
@@ -1,0 +1,111 @@
+import time
+from datetime import datetime
+
+import github3.exceptions
+
+from cumulusci.core.exceptions import GithubException, TaskOptionsError
+from cumulusci.tasks.github.base import BaseGithubTask
+
+
+class CreateFeatureBranchTag(BaseGithubTask):
+    """Records a feature-branch 2GP beta as an annotated git tag ONLY.
+
+    Unlike ``github_release`` (CreateRelease), this task never creates a GitHub
+    Release object. Feature-branch versions must not become Releases, or they
+    would be surfaced as the global "latest beta" by Release-based resolvers
+    such as ``GitHubBetaReleaseTagResolver``. Annotated git tags are read back
+    through the git refs API by ``GitHubFeatureBranchTagResolver``.
+
+    The version_id (04t) is embedded in the tag message in the same format used
+    by CreateRelease so it round-trips through ``get_version_id_from_tag``.
+    """
+
+    task_options = {
+        "version": {
+            "description": "The 2GP package version number. Ex: 2.5.0.1",
+            "required": True,
+        },
+        "version_id": {
+            "description": "The SubscriberPackageVersionId (04t) associated with this version.",
+            "required": True,
+        },
+        "commit": {
+            "description": (
+                "Override the commit used to create the tag. "
+                "Defaults to the current local HEAD commit"
+            )
+        },
+        "package_type": {
+            "description": "The package type of the project. Defaults to 2GP.",
+        },
+        "branch": {
+            "description": "The feature branch to tag. Defaults to the project's current repo branch."
+        },
+        "tag_prefix": {
+            "description": "The tag prefix (including trailing slash) to use for the tag. "
+            "Defaults to `<branch>/`."
+        },
+    }
+
+    def _init_options(self, kwargs):
+        super()._init_options(kwargs)
+
+        self.commit = self.options.get("commit", self.project_config.repo_commit)
+        if not self.commit:
+            message = "Could not detect the current commit from the local repo"
+            self.logger.error(message)
+            raise GithubException(message)
+        if len(self.commit) != 40:
+            raise TaskOptionsError("The commit option must be exactly 40 characters.")
+
+    def _run_task(self):
+        repo = self.get_repo()
+        version = self.options["version"]
+        package_type = self.options.get("package_type") or "2GP"
+
+        branch = self.options.get("branch") or self.project_config.repo_branch
+        if not branch:
+            raise TaskOptionsError(
+                "Could not detect the current branch; specify the `branch` option."
+            )
+        prefix = self.options.get("tag_prefix") or f"{branch}/"
+        tag_name = self.project_config.get_tag_for_version(prefix, version)
+
+        # Idempotency: no-op if the tag already exists.
+        try:
+            repo.ref(f"tags/{tag_name}")
+        except github3.exceptions.NotFoundError:
+            pass
+        else:
+            self.logger.info(f"Tag {tag_name} already exists; skipping.")
+            self.return_values = {"tag_name": tag_name}
+            return
+
+        # Embed version_id in the tag message in the same format CreateRelease
+        # uses so it round-trips through get_version_id_from_tag.
+        message = f"Feature branch package version {version}"
+        message += f"\n\nversion_id: {self.options['version_id']}"
+        message += f"\n\npackage_type: {package_type}"
+
+        # Create the annotated tag. lightweight=False creates both the tag object
+        # and the refs/tags/... ref in one call. We intentionally do NOT create a
+        # GitHub Release.
+        repo.create_tag(
+            tag=tag_name,
+            message=message,
+            sha=self.commit,
+            obj_type="commit",
+            tagger={
+                "name": self.github_config.username,
+                "email": self.github_config.email,
+                "date": f"{datetime.utcnow().isoformat()}Z",
+            },
+            lightweight=False,
+        )
+
+        # Sleep for GitHub to catch up with the fact that the tag exists.
+        time.sleep(3)
+
+        self.logger.info(f"Created annotated tag {tag_name} (no GitHub Release).")
+        self.return_values = {"tag_name": tag_name}
+        return self.return_values

--- a/cumulusci/tasks/github/tests/test_feature_branch_tag.py
+++ b/cumulusci/tasks/github/tests/test_feature_branch_tag.py
@@ -1,0 +1,127 @@
+import json
+from unittest import mock
+
+import responses
+
+from cumulusci.core.config import ServiceConfig, TaskConfig
+from cumulusci.tasks.github.feature_branch_tag import CreateFeatureBranchTag
+from cumulusci.tasks.github.tests.util_github_api import GithubApiTestMixin
+from cumulusci.tests.util import create_project_config
+
+
+class TestCreateFeatureBranchTag(GithubApiTestMixin):
+    def setup_method(self):
+        self.repo_owner = "TestOwner"
+        self.repo_name = "TestRepo"
+        self.commit_sha = "21e04cfe480f5293e2f7103eee8a5cbdb94f7982"
+        self.repo_api_url = "https://api.github.com/repos/{}/{}".format(
+            self.repo_owner, self.repo_name
+        )
+        self.project_config = create_project_config(self.repo_name, self.repo_owner)
+        self.project_config.keychain.set_service(
+            "github",
+            "test_alias",
+            ServiceConfig(
+                {
+                    "username": "TestUser",
+                    "token": "TestPass",
+                    "email": "testuser@testdomain.com",
+                }
+            ),
+        )
+
+    def _task(self, options=None):
+        opts = {
+            "version": "2.5.0.1",
+            "version_id": "04t000000000001",
+            "commit": self.commit_sha,
+            "branch": "feature/DEVOPS-573",
+        }
+        opts.update(options or {})
+        return CreateFeatureBranchTag(
+            self.project_config, TaskConfig({"options": opts})
+        )
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.feature_branch_tag.time.sleep")
+    def test_run_task__creates_annotated_tag(self, sleep):
+        expected_tag_name = "feature/DEVOPS-573/2.5.0.1"
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        # Idempotency check: ref does not yet exist.
+        responses.add(
+            responses.GET,
+            self.repo_api_url + f"/git/ref/tags/{expected_tag_name}",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            self.repo_api_url + "/git/tags",
+            json=self._get_expected_tag(expected_tag_name, self.commit_sha),
+            status=201,
+        )
+        responses.add(
+            responses.POST, self.repo_api_url + "/git/refs", json={}, status=201
+        )
+
+        task = self._task()
+        task()
+
+        assert task.return_values["tag_name"] == expected_tag_name
+
+        # An annotated tag object was created (POST /git/tags) with the
+        # version_id embedded in the message so get_version_id_from_tag can read it.
+        tag_calls = [c for c in responses.calls if c.request.url.endswith("/git/tags")]
+        assert len(tag_calls) == 1
+        body = json.loads(tag_calls[0].request.body)
+        assert body["tag"] == expected_tag_name
+        assert "version_id: 04t000000000001" in body["message"]
+        assert "package_type: 2GP" in body["message"]
+        assert body["object"] == self.commit_sha
+        assert body["type"] == "commit"
+        assert body["tagger"]["name"] == "TestUser"
+
+        # The ref was created (lightweight=False creates both objects).
+        ref_calls = [c for c in responses.calls if c.request.url.endswith("/git/refs")]
+        assert len(ref_calls) == 1
+
+        # No GitHub Release was created.
+        release_calls = [
+            c for c in responses.calls if c.request.url.endswith("/releases")
+        ]
+        assert release_calls == []
+
+        sleep.assert_called_once()
+
+    @responses.activate
+    @mock.patch("cumulusci.tasks.github.feature_branch_tag.time.sleep")
+    def test_run_task__idempotent_when_tag_exists(self, sleep):
+        expected_tag_name = "feature/DEVOPS-573/2.5.0.1"
+        responses.add(
+            method=responses.GET,
+            url=self.repo_api_url,
+            json=self._get_expected_repo(owner=self.repo_owner, name=self.repo_name),
+        )
+        # Ref already exists.
+        responses.add(
+            responses.GET,
+            self.repo_api_url + f"/git/ref/tags/{expected_tag_name}",
+            json={
+                "object": {"sha": "SHA", "url": "", "type": "tag"},
+                "url": "",
+                "ref": f"refs/tags/{expected_tag_name}",
+            },
+            status=200,
+        )
+
+        task = self._task()
+        task()
+
+        assert task.return_values["tag_name"] == expected_tag_name
+        # No tag/ref/release POSTs were made.
+        post_calls = [c for c in responses.calls if c.request.method == "POST"]
+        assert post_calls == []
+        sleep.assert_not_called()

--- a/cumulusci/tasks/github/tests/test_feature_branch_tag.py
+++ b/cumulusci/tasks/github/tests/test_feature_branch_tag.py
@@ -35,7 +35,7 @@ class TestCreateFeatureBranchTag(GithubApiTestMixin):
             "version": "2.5.0.1",
             "version_id": "04t000000000001",
             "commit": self.commit_sha,
-            "branch": "feature/DEVOPS-573",
+            "branch": "feature/widget",
         }
         opts.update(options or {})
         return CreateFeatureBranchTag(
@@ -45,7 +45,7 @@ class TestCreateFeatureBranchTag(GithubApiTestMixin):
     @responses.activate
     @mock.patch("cumulusci.tasks.github.feature_branch_tag.time.sleep")
     def test_run_task__creates_annotated_tag(self, sleep):
-        expected_tag_name = "feature/DEVOPS-573/2.5.0.1"
+        expected_tag_name = "feature/widget/2.5.0.1"
         responses.add(
             method=responses.GET,
             url=self.repo_api_url,
@@ -99,7 +99,7 @@ class TestCreateFeatureBranchTag(GithubApiTestMixin):
     @responses.activate
     @mock.patch("cumulusci.tasks.github.feature_branch_tag.time.sleep")
     def test_run_task__idempotent_when_tag_exists(self, sleep):
-        expected_tag_name = "feature/DEVOPS-573/2.5.0.1"
+        expected_tag_name = "feature/widget/2.5.0.1"
         responses.add(
             method=responses.GET,
             url=self.repo_api_url,

--- a/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
@@ -132,6 +132,27 @@ def test_init_options_uses_include_beta_strategy_for_include_beta_true():
     assert DependencyResolutionStrategy.BETA_RELEASE_TAG in task.resolution_strategy
 
 
+def test_init_options_sets_active_feature_branch_in_context():
+    task = create_task(
+        UpdateDependencies,
+        {
+            "dependencies": [
+                {
+                    "namespace": "ns",
+                    "version": "1.0",
+                }
+            ],
+            "resolution_strategy": "feature_branch",
+            "feature_branch": "feature/DEVOPS-573",
+        },
+    )
+
+    assert (
+        task.project_config.lookup("project__git__active_feature_branch")
+        == "feature/DEVOPS-573"
+    )
+
+
 def test_init_options_removes_beta_resolver_for_include_beta_false():
     task = create_task(
         UpdateDependencies,

--- a/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
+++ b/cumulusci/tasks/salesforce/tests/test_update_dependencies.py
@@ -132,7 +132,7 @@ def test_init_options_uses_include_beta_strategy_for_include_beta_true():
     assert DependencyResolutionStrategy.BETA_RELEASE_TAG in task.resolution_strategy
 
 
-def test_init_options_sets_active_feature_branch_in_context():
+def test_feature_branch_overlay_is_scoped_and_restored():
     task = create_task(
         UpdateDependencies,
         {
@@ -143,14 +143,34 @@ def test_init_options_sets_active_feature_branch_in_context():
                 }
             ],
             "resolution_strategy": "feature_branch",
-            "feature_branch": "feature/DEVOPS-573",
+            "feature_branch": "feature/widget",
         },
     )
 
-    assert (
-        task.project_config.lookup("project__git__active_feature_branch")
-        == "feature/DEVOPS-573"
+    # The overlay is not set until resolution runs, so it does not leak from
+    # _init_options into other steps sharing the same project_config.
+    assert task.project_config.lookup("project__git__active_feature_branch") is None
+
+    with task._feature_branch_overlay():
+        assert (
+            task.project_config.lookup("project__git__active_feature_branch")
+            == "feature/widget"
+        )
+
+    # Restored (removed) once resolution completes.
+    assert task.project_config.lookup("project__git__active_feature_branch") is None
+
+
+def test_feature_branch_overlay_noop_without_option():
+    task = create_task(
+        UpdateDependencies,
+        {
+            "dependencies": [{"namespace": "ns", "version": "1.0"}],
+        },
     )
+
+    with task._feature_branch_overlay():
+        assert task.project_config.lookup("project__git__active_feature_branch") is None
 
 
 def test_init_options_removes_beta_resolver_for_include_beta_false():

--- a/cumulusci/tasks/salesforce/update_dependencies.py
+++ b/cumulusci/tasks/salesforce/update_dependencies.py
@@ -55,6 +55,10 @@ class UpdateDependencies(BaseSalesforceTask):
         "resolution_strategy": {
             "description": "The name of a sequence of resolution_strategy (from project__dependency_resolutions) to apply to dynamic dependencies."
         },
+        "feature_branch": {
+            "description": "The feature branch to resolve feature-branch 2GP betas from. "
+            "When set, the feature_branch_tag resolver will scan annotated git tags under this branch's prefix."
+        },
         "packages_only": {
             "description": "Install only packaged dependencies. Ignore all unmanaged metadata. Defaults to False."
         },
@@ -180,6 +184,16 @@ class UpdateDependencies(BaseSalesforceTask):
                 "The include_beta and prefer_2gp_from_release_branch options "
                 "for update_dependencies are deprecated. Use resolution strategies instead."
             )
+
+        # If a feature branch is specified, overlay it into the project config
+        # context so the feature_branch_tag resolver can read it via
+        # context.lookup("project__git__active_feature_branch").
+        feature_branch = self.options.get("feature_branch")
+        if feature_branch:
+            git_config = self.project_config.config.setdefault(
+                "project", {}
+            ).setdefault("git", {})
+            git_config["active_feature_branch"] = feature_branch
 
         self.install_options = PackageInstallOptions.from_task_options(self.options)
 

--- a/cumulusci/tasks/salesforce/update_dependencies.py
+++ b/cumulusci/tasks/salesforce/update_dependencies.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import List
 
 import click
@@ -143,6 +144,9 @@ class UpdateDependencies(BaseSalesforceTask):
         unsafe_prod_resolvers = [
             *resolvers_2gp,
             DependencyResolutionStrategy.BETA_RELEASE_TAG,
+            # feature_branch_tag resolves to unpromoted 2GP beta package IDs,
+            # so it must be stripped for persistent orgs like the other betas.
+            DependencyResolutionStrategy.FEATURE_BRANCH_TAG,
         ]
 
         force_strategy = process_bool_arg(
@@ -185,16 +189,6 @@ class UpdateDependencies(BaseSalesforceTask):
                 "for update_dependencies are deprecated. Use resolution strategies instead."
             )
 
-        # If a feature branch is specified, overlay it into the project config
-        # context so the feature_branch_tag resolver can read it via
-        # context.lookup("project__git__active_feature_branch").
-        feature_branch = self.options.get("feature_branch")
-        if feature_branch:
-            git_config = self.project_config.config.setdefault(
-                "project", {}
-            ).setdefault("git", {})
-            git_config["active_feature_branch"] = feature_branch
-
         self.install_options = PackageInstallOptions.from_task_options(self.options)
 
         # Interactivity options
@@ -215,6 +209,33 @@ class UpdateDependencies(BaseSalesforceTask):
             or not self.options["packages_only"]
         ]
 
+    @contextlib.contextmanager
+    def _feature_branch_overlay(self):
+        """Temporarily overlay the `feature_branch` option into the shared
+        project_config as `project__git__active_feature_branch` so the
+        feature_branch_tag resolver can read it, then restore the previous
+        value. Scoping the overlay prevents it from leaking into later
+        task/flow steps that share the same project_config instance.
+        """
+        feature_branch = self.options.get("feature_branch")
+        if not feature_branch:
+            yield
+            return
+
+        git_config = self.project_config.config.setdefault("project", {}).setdefault(
+            "git", {}
+        )
+        sentinel = object()
+        previous = git_config.get("active_feature_branch", sentinel)
+        git_config["active_feature_branch"] = feature_branch
+        try:
+            yield
+        finally:
+            if previous is sentinel:
+                git_config.pop("active_feature_branch", None)
+            else:
+                git_config["active_feature_branch"] = previous
+
     def _run_task(self):
         if not self.dependencies:
             self.logger.info("Project has no dependencies, doing nothing")
@@ -228,14 +249,15 @@ class UpdateDependencies(BaseSalesforceTask):
         else:
             filter_function = None
 
-        dependencies = self._filter_dependencies(
-            get_static_dependencies(
-                self.project_config,
-                dependencies=self.dependencies,
-                strategies=self.resolution_strategy,
-                filter_function=filter_function,
+        with self._feature_branch_overlay():
+            dependencies = self._filter_dependencies(
+                get_static_dependencies(
+                    self.project_config,
+                    dependencies=self.dependencies,
+                    strategies=self.resolution_strategy,
+                    filter_function=filter_function,
+                )
             )
-        )
         self.logger.info("Collected dependencies:")
 
         for d in dependencies:
@@ -353,14 +375,15 @@ class UpdateDependencies(BaseSalesforceTask):
         else:
             filter_function = None
 
-        dependencies = self._filter_dependencies(
-            get_static_dependencies(
-                self.project_config,
-                dependencies=self.dependencies,
-                strategies=self.resolution_strategy,
-                filter_function=filter_function,
+        with self._feature_branch_overlay():
+            dependencies = self._filter_dependencies(
+                get_static_dependencies(
+                    self.project_config,
+                    dependencies=self.dependencies,
+                    strategies=self.resolution_strategy,
+                    filter_function=filter_function,
+                )
             )
-        )
 
         steps = []
         for i, dependency in enumerate(dependencies, start=1):

--- a/cumulusci/tasks/tests/test_create_package_version.py
+++ b/cumulusci/tasks/tests/test_create_package_version.py
@@ -596,7 +596,7 @@ class TestCreatePackageVersion:
             {
                 "package_type": "Managed",
                 "package_name": "Test Package",
-                "branch": "feature/DEVOPS-573",
+                "branch": "feature/widget",
             }
         )
         responses.add(
@@ -611,7 +611,7 @@ class TestCreatePackageVersion:
         )
         assert result == "08c000000000001AAA"
         query = responses.calls[-1].request.params["q"]
-        assert "AND Branch = 'feature/DEVOPS-573'" in query
+        assert "AND Branch = 'feature/widget'" in query
 
     @responses.activate
     def test_create_version_request__dedup_query_no_branch(self, get_task):
@@ -648,7 +648,7 @@ class TestCreatePackageVersion:
                 "package_name": "Test Package",
                 "skip_validation": True,
                 "force_upload": True,
-                "branch": "feature/DEVOPS-573",
+                "branch": "feature/widget",
             }
         )
         # Base-version lookup (no existing versions)
@@ -674,7 +674,7 @@ class TestCreatePackageVersion:
         assert result == "08c000000000002AAA"
         post_call = [c for c in responses.calls if c.request.method == "POST"][0]
         body = json.loads(post_call.request.body)
-        assert body["Branch"] == "feature/DEVOPS-573"
+        assert body["Branch"] == "feature/widget"
 
     @responses.activate
     def test_create_version_request__no_branch_omits_field(self, get_task):

--- a/cumulusci/tasks/tests/test_create_package_version.py
+++ b/cumulusci/tasks/tests/test_create_package_version.py
@@ -590,6 +590,94 @@ class TestCreatePackageVersion:
         )
         assert result == "08c000000000001AAA"
 
+    @responses.activate
+    def test_create_version_request__dedup_query_scopes_to_branch(self, get_task):
+        task = get_task(
+            {
+                "package_type": "Managed",
+                "package_name": "Test Package",
+                "branch": "feature/DEVOPS-573",
+            }
+        )
+        responses.add(
+            "GET",
+            f"{self.devhub_base_url}/tooling/query/",
+            json={"size": 1, "records": [{"Id": "08c000000000001AAA"}]},
+        )
+
+        builder = BasePackageZipBuilder()
+        result = task._create_version_request(
+            "0Ho6g000000fy4ZCAQ", task.package_config, builder
+        )
+        assert result == "08c000000000001AAA"
+        query = responses.calls[-1].request.params["q"]
+        assert "AND Branch = 'feature/DEVOPS-573'" in query
+
+    @responses.activate
+    def test_create_version_request__dedup_query_no_branch(self, get_task):
+        task = get_task(
+            {
+                "package_type": "Managed",
+                "package_name": "Test Package",
+            }
+        )
+        # Force repo_branch to None so no branch is in scope.
+        with mock.patch.object(
+            type(task.project_config),
+            "repo_branch",
+            new_callable=mock.PropertyMock,
+            return_value=None,
+        ):
+            responses.add(
+                "GET",
+                f"{self.devhub_base_url}/tooling/query/",
+                json={"size": 1, "records": [{"Id": "08c000000000001AAA"}]},
+            )
+
+            builder = BasePackageZipBuilder()
+            result = task._create_version_request(
+                "0Ho6g000000fy4ZCAQ", task.package_config, builder
+            )
+        assert result == "08c000000000001AAA"
+        query = responses.calls[-1].request.params["q"]
+        assert "Branch =" not in query
+
+    @responses.activate
+    def test_create_version_request__adds_branch_to_request(self, get_task):
+        task = get_task(
+            {
+                "package_type": "Managed",
+                "package_name": "Test Package",
+                "skip_validation": True,
+                "force_upload": True,
+                "branch": "feature/DEVOPS-573",
+            }
+        )
+        # Base-version lookup (no existing versions)
+        responses.add(
+            "GET",
+            f"{self.devhub_base_url}/tooling/query/",
+            json={"size": 0, "records": []},
+        )
+        # POST to create the Package2VersionCreateRequest
+        responses.add(
+            "POST",
+            f"{self.devhub_base_url}/tooling/sobjects/Package2VersionCreateRequest/",
+            json={"id": "08c000000000002AAA"},
+        )
+
+        builder = BasePackageZipBuilder()
+        result = task._create_version_request(
+            "0Ho6g000000fy4ZCAQ",
+            task.package_config,
+            builder,
+            skip_validation=True,
+        )
+        assert result == "08c000000000002AAA"
+        post_call = [c for c in responses.calls if c.request.method == "POST"][0]
+        body = json.loads(post_call.request.body)
+        assert body["Branch"] == "feature/DEVOPS-573"
+
     def test_has_1gp_namespace_dependencies__no(self, task):
         assert not task._has_1gp_namespace_dependency([])
 

--- a/cumulusci/tasks/tests/test_create_package_version.py
+++ b/cumulusci/tasks/tests/test_create_package_version.py
@@ -615,32 +615,30 @@ class TestCreatePackageVersion:
 
     @responses.activate
     def test_create_version_request__dedup_query_no_branch(self, get_task):
+        # The branch option is opt-in: when it is omitted the Branch field is
+        # not set and the dedup query is not scoped, even though repo_branch is
+        # populated ("main" in this fixture). This preserves the pre-feature
+        # behavior for every build that does not ask for branch scoping.
         task = get_task(
             {
                 "package_type": "Managed",
                 "package_name": "Test Package",
             }
         )
-        # Force repo_branch to None so no branch is in scope.
-        with mock.patch.object(
-            type(task.project_config),
-            "repo_branch",
-            new_callable=mock.PropertyMock,
-            return_value=None,
-        ):
-            responses.add(
-                "GET",
-                f"{self.devhub_base_url}/tooling/query/",
-                json={"size": 1, "records": [{"Id": "08c000000000001AAA"}]},
-            )
+        assert task.project_config.repo_branch  # repo_branch is set...
+        responses.add(
+            "GET",
+            f"{self.devhub_base_url}/tooling/query/",
+            json={"size": 1, "records": [{"Id": "08c000000000001AAA"}]},
+        )
 
-            builder = BasePackageZipBuilder()
-            result = task._create_version_request(
-                "0Ho6g000000fy4ZCAQ", task.package_config, builder
-            )
+        builder = BasePackageZipBuilder()
+        result = task._create_version_request(
+            "0Ho6g000000fy4ZCAQ", task.package_config, builder
+        )
         assert result == "08c000000000001AAA"
         query = responses.calls[-1].request.params["q"]
-        assert "Branch =" not in query
+        assert "Branch =" not in query  # ...but no Branch filter without the option
 
     @responses.activate
     def test_create_version_request__adds_branch_to_request(self, get_task):
@@ -677,6 +675,41 @@ class TestCreatePackageVersion:
         post_call = [c for c in responses.calls if c.request.method == "POST"][0]
         body = json.loads(post_call.request.body)
         assert body["Branch"] == "feature/DEVOPS-573"
+
+    @responses.activate
+    def test_create_version_request__no_branch_omits_field(self, get_task):
+        # Backward-compat guard: with no branch option the request body must not
+        # carry a Branch field, even though repo_branch is set.
+        task = get_task(
+            {
+                "package_type": "Managed",
+                "package_name": "Test Package",
+                "skip_validation": True,
+                "force_upload": True,
+            }
+        )
+        assert task.project_config.repo_branch
+        responses.add(
+            "GET",
+            f"{self.devhub_base_url}/tooling/query/",
+            json={"size": 0, "records": []},
+        )
+        responses.add(
+            "POST",
+            f"{self.devhub_base_url}/tooling/sobjects/Package2VersionCreateRequest/",
+            json={"id": "08c000000000002AAA"},
+        )
+
+        builder = BasePackageZipBuilder()
+        task._create_version_request(
+            "0Ho6g000000fy4ZCAQ",
+            task.package_config,
+            builder,
+            skip_validation=True,
+        )
+        post_call = [c for c in responses.calls if c.request.method == "POST"][0]
+        body = json.loads(post_call.request.body)
+        assert "Branch" not in body
 
     def test_has_1gp_namespace_dependencies__no(self, task):
         assert not task._has_1gp_namespace_dependency([])

--- a/docs/2gp-testing.md
+++ b/docs/2gp-testing.md
@@ -192,6 +192,29 @@ When no feature branch is supplied, the strategy falls through to the
 latest beta and then the latest release, so it is safe to leave
 configured as a default.
 
+To resolve the newest branch beta for a *specific* dependency, set the
+`feature_branch` field directly on that dependency. This is useful when
+different dependencies track different branches, or when only one
+dependency should follow a branch while the rest use their normal
+resolution:
+
+```yaml
+project:
+    dependencies:
+        - github: https://github.com/example-org/package-a
+          feature_branch: epic/new-billing
+        - github: https://github.com/example-org/package-b
+          feature_branch: epic/other-work
+        - github: https://github.com/example-org/package-c
+```
+
+The dependency's `feature_branch` takes precedence over any run-wide
+`feature_branch` option and over the current branch. Package C, with no
+`feature_branch`, resolves normally (latest beta, then release). This
+still requires the `feature_branch` strategy to be active (via the
+`feature_org` flow, a resolution alias, or the `resolution_strategy`
+option).
+
 (end-to-end-testing-with-second-generation-packages)=
 
 ## End-to-End Testing with Second-Generation Packages

--- a/docs/2gp-testing.md
+++ b/docs/2gp-testing.md
@@ -86,6 +86,65 @@ which operates just like `ci_feature_2gp` but which also executes
 may be executed against 2GP orgs by running `qa_org_2gp` instead of
 `qa_org` before invoking `robot`.
 
+## Feature and Epic Branch Betas via Annotated Git Tags
+
+The commit-status process above targets `feature/NNN` release branches.
+For arbitrarily named feature or epic branches (for example
+`epic/new-billing`), CumulusCI can instead record a 2GP beta as
+an **annotated git tag** and resolve it when building an org from that
+branch. This lets QA and developers spin up a scratch org seeded with the
+in-flight package version for a specific branch without hand-specifying a
+`version_id`.
+
+Feature-branch betas are recorded as annotated git tags **only**, never
+as GitHub Releases. This is deliberate: a feature-branch GitHub Release
+would be returned as the global "latest beta" to every consumer of the
+`include_beta` and `commit_status` strategies, a silent cross-repository
+regression. Annotated tags are read through the git refs API and are
+invisible to every Release-based resolver.
+
+### Building and recording the beta
+
+1.  Build the 2GP package version. To give a branch its own build-number
+    sequence, pass the `branch` option to `create_package_version`. This
+    sets the `Branch` field on the `Package2VersionCreateRequest`, and
+    Salesforce scopes the build counter independently per
+    `(package, major.minor.patch, branch)`. The option is opt-in: when it
+    is omitted the `Branch` field is not set and counting is unscoped,
+    exactly as before.
+
+        cci task run create_package_version --branch epic/new-billing
+
+2.  Record the resulting version as an annotated git tag with the
+    `create_feature_branch_tag` task. The tag is named
+    `<branch>/<version>` (for example
+    `epic/new-billing/1.2.0.1`) and embeds the `version_id`
+    (`04t`) in its message. No GitHub Release is created.
+
+        cci task run create_feature_branch_tag \
+            --version 1.2.0.1 \
+            --version-id 04tXXXXXXXXXXXXXXX
+
+### Building an org from the beta
+
+Run the `feature_org` flow, which uses the `feature_branch` resolution
+strategy. When run from a repository already checked out on the feature
+branch, the branch is detected automatically:
+
+    cci flow run feature_org --org feature
+
+For a repository that stays on `main` (such as a solution-org project
+that aggregates many dependencies), name the branch explicitly. Every
+dependency repository that has a matching feature-branch tag resolves to
+it; those that do not fall through to the latest beta and then the latest
+release, so mixed sets of dependencies resolve correctly:
+
+    cci flow run feature_org --org feature \
+        -o update_dependencies.feature_branch=epic/new-billing
+
+See [](controlling-github-dependency-resolution) for the full ordered
+list of resolvers in the `feature_branch` strategy.
+
 (end-to-end-testing-with-second-generation-packages)=
 
 ## End-to-End Testing with Second-Generation Packages

--- a/docs/2gp-testing.md
+++ b/docs/2gp-testing.md
@@ -145,6 +145,43 @@ release, so mixed sets of dependencies resolve correctly:
 See [](controlling-github-dependency-resolution) for the full ordered
 list of resolvers in the `feature_branch` strategy.
 
+### Declaring the dependency in `cumulusci.yml`
+
+A downstream project can consume a branch beta through its
+`cumulusci.yml` in two ways.
+
+To install one specific branch beta deterministically, pin the annotated
+tag on a GitHub dependency. Because the tag carries the package
+`version_id` in its message, the `tag` resolver installs exactly that
+second-generation package version, with no resolution strategy involved:
+
+```yaml
+project:
+    dependencies:
+        - github: https://github.com/example-org/example-package
+          tag: epic/new-billing/1.2.0.1
+```
+
+To resolve the newest branch beta dynamically instead of pinning a fixed
+version, point a resolution alias at the `feature_branch` strategy so
+development flows use it, then supply the branch at run time:
+
+```yaml
+project:
+    dependency_resolutions:
+        preproduction: feature_branch
+        production: latest_release
+```
+
+```console
+$ cci flow run dev_org --org dev \
+    -o update_dependencies.feature_branch=epic/new-billing
+```
+
+When no feature branch is supplied, the strategy falls through to the
+latest beta and then the latest release, so it is safe to leave
+configured as a default.
+
 (end-to-end-testing-with-second-generation-packages)=
 
 ## End-to-End Testing with Second-Generation Packages

--- a/docs/2gp-testing.md
+++ b/docs/2gp-testing.md
@@ -113,17 +113,23 @@ invisible to every Release-based resolver.
     is omitted the `Branch` field is not set and counting is unscoped,
     exactly as before.
 
-        cci task run create_package_version --branch epic/new-billing
+    ```console
+    $ cci task run create_package_version --branch epic/new-billing
+    ```
 
 2.  Record the resulting version as an annotated git tag with the
-    `create_feature_branch_tag` task. The tag is named
-    `<branch>/<version>` (for example
-    `epic/new-billing/1.2.0.1`) and embeds the `version_id`
-    (`04t`) in its message. No GitHub Release is created.
+    `create_feature_branch_tag` task. Pass the same `--branch` so the tag
+    is created under the intended prefix regardless of the current
+    checkout. The tag is named `<branch>/<version>` (for example
+    `epic/new-billing/1.2.0.1`) and embeds the `version_id` (`04t`) in its
+    message. No GitHub Release is created.
 
-        cci task run create_feature_branch_tag \
-            --version 1.2.0.1 \
-            --version-id 04tXXXXXXXXXXXXXXX
+    ```console
+    $ cci task run create_feature_branch_tag \
+        --branch epic/new-billing \
+        --version 1.2.0.1 \
+        --version-id 04tXXXXXXXXXXXXXXX
+    ```
 
 ### Building an org from the beta
 
@@ -131,7 +137,9 @@ Run the `feature_org` flow, which uses the `feature_branch` resolution
 strategy. When run from a repository already checked out on the feature
 branch, the branch is detected automatically:
 
-    cci flow run feature_org --org feature
+```console
+$ cci flow run feature_org --org feature
+```
 
 For a repository that stays on `main` (such as a solution-org project
 that aggregates many dependencies), name the branch explicitly. Every
@@ -139,11 +147,13 @@ dependency repository that has a matching feature-branch tag resolves to
 it; those that do not fall through to the latest beta and then the latest
 release, so mixed sets of dependencies resolve correctly:
 
-    cci flow run feature_org --org feature \
-        -o update_dependencies.feature_branch=epic/new-billing
+```console
+$ cci flow run feature_org --org feature \
+    -o update_dependencies.feature_branch=epic/new-billing
+```
 
-See [](controlling-github-dependency-resolution) for the full ordered
-list of resolvers in the `feature_branch` strategy.
+See [Controlling GitHub Dependency Resolution](controlling-github-dependency-resolution)
+for the full ordered list of resolvers in the `feature_branch` strategy.
 
 ### Declaring the dependency in `cumulusci.yml`
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -572,6 +572,13 @@ library:
 >     betas created on feature branches, if any, or the main branch,
 >     before falling back to managed package releases. This strategy
 >     is used only in the `qa_org_2gp` and `ci_feature_2gp` flows.
+> -   `feature_branch`, which will resolve to a second-generation package
+>     beta recorded as an annotated git tag on a named feature or epic
+>     branch, if any, before falling back to the latest beta and then the
+>     latest managed release. This strategy is used in the `feature_org`
+>     flow. Unlike `commit_status`, it supports arbitrarily named branches
+>     (not only `feature/NNN` release branches) and reads annotated git
+>     tags rather than commit statuses.
 > -   `unlocked`, which will resolve to unlocked package betas
 >     created on feature branches, if any, or the main branch.
 >     This strategy does _not_ fall back to managed package releases,
@@ -714,6 +721,39 @@ Package versions are used for ongoing QA.
 > -   If a commit status contains a beta package Id for any of the first
 >     five commits on the default branch, use that commit and package.
 >     (Resolver: `unlocked_default_branch`)
+
+**feature_branch**:
+
+This resolution strategy is suitable for building an org from a named
+feature or epic branch (for example `epic/new-billing`) whose
+second-generation package beta has been recorded as an annotated git tag
+by the `create_feature_branch_tag` task. Unlike `commit_status`, it is
+not limited to `feature/NNN` release branches and does not depend on
+commit statuses.
+
+The feature branch name is taken from the `feature_branch` option of the
+`update_dependencies` task, if set; otherwise from the current branch
+when it begins with the feature branch prefix. When neither yields a
+feature branch, the `feature_branch_tag` resolver is skipped and the
+strategy falls through to the beta and release resolvers, so it is always
+safe to run.
+
+> -   If a `tag` is present, use the commit for that tag, and any package
+>     version found there. (Resolver: `tag`)
+> -   In the dependency repository, find annotated git tags under the
+>     `<feature-branch>/` prefix. Use the highest package version found and
+>     its commit. Feature-branch betas are recorded as annotated git tags
+>     only, never GitHub Releases, so they remain invisible to the
+>     `latest_beta` resolver and never leak across repositories as a global
+>     "latest beta." (Resolver: `feature_branch_tag`)
+> -   Identify the most recent beta package release via the GitHub
+>     Releases section. If located, use that package and commit.
+>     (Resolver: `latest_beta`)
+> -   Identify the most recent production package release via the GitHub
+>     Releases section. If located, use that package and commit.
+>     (Resolver: `latest_release`)
+> -   Use the most recent commit on the repository's main branch as an
+>     unmanaged dependency. (Resolver: `unmanaged`)
 
 #### Customizing Resolution Strategies
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -379,6 +379,12 @@ project:
 The EDA repository's tag `rel/1.105` is used instead of the latest
 production release of EDA (1.111, for this example).
 
+This also works with feature-branch beta tags created by the
+`create_feature_branch_tag` task (for example
+`epic/new-billing/1.2.0.1`). Because the annotated tag's message carries
+the package `version_id`, pinning it installs that exact
+second-generation package version.
+
 #### Skip `unpackaged/*` in Reference Repositories
 
 If the referenced repository has unpackaged metadata under

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -737,11 +737,13 @@ by the `create_feature_branch_tag` task. Unlike `commit_status`, it is
 not limited to `feature/NNN` release branches and does not depend on
 commit statuses.
 
-The feature branch name is taken from the `feature_branch` option of the
-`update_dependencies` task, if set; otherwise from the current branch
-when it begins with the feature branch prefix. When neither yields a
-feature branch, the `feature_branch_tag` resolver is skipped and the
-strategy falls through to the beta and release resolvers, so it is always
+The feature branch name is resolved in priority order: a `feature_branch`
+field set on the individual dependency, then the `feature_branch` option
+of the `update_dependencies` task, then the current branch when it is not
+the default branch. A per-dependency `feature_branch` lets different
+dependencies follow different branches. When none yields a feature
+branch, the `feature_branch_tag` resolver is skipped and the strategy
+falls through to the beta and release resolvers, so it is always
 safe to run.
 
 > -   If a `tag` is present, use the commit for that tag, and any package


### PR DESCRIPTION
## Overview

Adds first-class support for feature/epic-branch 2GP betas. QA and developers can build a scratch org seeded with the correct in-flight package version for a given feature branch, without hand-specifying a `version_id`.

Feature-branch betas are recorded as **annotated git tags only** (never GitHub Releases). This is deliberate: `github.py::get_latest_prerelease()` runs a GraphQL `releases` query with no tag-prefix filter, and `GitHubBetaReleaseTagResolver` (the `latest_beta` strategy) depends on it. Any feature-branch GitHub Release would therefore be surfaced as the global "latest beta" to every consumer - a silent cross-repo regression. Annotated tags read via the git refs API are invisible to all Release-based resolvers.

## Changes

- **`cumulusci/core/github.py`** - new `get_tag_refs_for_prefix()`; lists annotated tags via the git refs API (`repo.refs("tags/<prefix>")`), never the Releases API.
- **`cumulusci/core/dependencies/resolvers.py`** - new `feature_branch_tag` strategy (`FEATURE_BRANCH_TAG`) and `GitHubFeatureBranchTagResolver`; resolves the highest-versioned tag under the current feature branch's prefix, short-circuits cleanly when there is no feature-branch context.
- **`cumulusci/tasks/create_package_version.py`** - new **opt-in** `branch` option. When passed, sets the `Branch` field on `Package2VersionCreateRequest` (scoping the build counter per branch) and scopes the content-dedup query to that branch. When omitted, no `Branch` field is sent - behavior is identical to before.
- **`cumulusci/tasks/github/feature_branch_tag.py`** *(new)* - `CreateFeatureBranchTag` task; creates an annotated tag with the `version_id` embedded in the message (round-trips through `get_version_id_from_tag`), idempotent, creates no GitHub Release.
- **`cumulusci/tasks/salesforce/update_dependencies.py`** - new `feature_branch` option; overlays `project__git__active_feature_branch` so resolvers can read it via `context.lookup(...)`.
- **`cumulusci/cumulusci.yml`** - `feature_branch` resolution stack (`tag, feature_branch_tag, latest_beta, latest_release, unmanaged`), the `create_feature_branch_tag` task, and a `feature_org` flow.
- **`docs/2gp-testing.md`, `docs/dev.md`** - document the `feature_branch` resolution strategy, the annotated-tag beta workflow, and how to declare a branch beta in `cumulusci.yml`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation

All changes are additive: a new enum member, a new resolver, a new task, a new optional task option on two existing tasks, and new config entries. No existing behavior changes when the new options are not used. In particular, `create_package_version` sets the `Branch` field only when `branch` is explicitly passed.

## Testing

- `uv run pytest` on all touched modules: **169 passed**.
- Added unit tests: resolver (highest-version selection, short-circuit, branch-name resolution), `create_package_version` (Branch field + branch-scoped dedup, including that no `Branch` field/filter is emitted without the option), the new task (idempotency, annotated tag, no Release), and `update_dependencies` (option overlay).
- `black` 22.3.0 (pre-commit pin) and `isort` 5.12.0 clean on all changed files.

## Related

- Jira: DEVOPS-573 (Epic: DEVOPS-481)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature-branch beta dependency resolution using annotated Git tags (with per-dependency branch override).
  * Added the `feature_org` flow for provisioning environments from feature-branch dependencies.
  * Added a task to create branch-scoped annotated beta tags without publishing GitHub Releases (idempotent if the tag already exists).
  * Added optional branch-scoped build numbering for package versions.
* **Documentation**
  * Documented the feature-branch beta workflow, configuration, fallback behavior, and how to reference feature-branch tags.
* **Tests**
  * Added unit tests covering tag discovery/parsing, resolver behavior, tag creation, dependency update overlay, and branch-scoped version request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->