### PR TITLE
DEVOPS-947 fix: upgrade gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             - name: Build source tarball and binary wheel
               run: hatch build -c
             - name: Publish to PyPI (Trusted Publishing)
-              uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+              uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
               # No credentials needed - uses OIDC trusted publishing
             - name: Create GitHub release
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             - name: Build source tarball and binary wheel
               run: hatch build -c
             - name: Publish to PyPI (Trusted Publishing)
-              uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+              uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
               # No credentials needed - uses OIDC trusted publishing
             - name: Create GitHub release
               env:


### PR DESCRIPTION
## Overview

<sup>_Provide a concise overview of the changes in this PR. Highlight the problem or feature addressed, linking to relevant issues or feature requests when applicable. Consider using tools like Loom for visual explanations or complex discussions._</sup>

Upgrades `gh-action-pypi-publish` from v1.13.0 to v1.14.2 to fix CI PyPI publish failures. hatchling 1.27.0 introduced wheel metadata version 2.5, which the previously pinned action (v1.13.0, bundling twine v6) rejects as invalid. v1.14.2 ships with twine v7 which explicitly adds metadata 2.5 support. The `4.8.0.dev0` release was published manually as a workaround while this fix was investigated.

### Related Jira Tickets

<sup>_Mention any Jira tickets related to this PR. This section will be auto-updated based on commit messages in the future._</sup>

- DEVOPS-947

### Related Documents

<sup>_Mention any relevant documents, designs, or resources that are related to this PR. This could include links to Figma/Miro designs, architecture diagrams, or other resources._</sup>

-

## Changes Proposed

<sup>_Detail the changes introduced by this PR. Categorize your changes to help reviewers understand the scope and impact._</sup>

### Types of Changes

<sup>_Indicate the type of changes your PR introduces to the project. Check the box that applies by replacing `[ ]` with `[x]` and Ensure you understand the implications of each type._</sup>

- [x] Bug fix (non-breaking changes which fix an issue)
- [ ] New feature (non-breaking changes which add functionality)
- [ ] Breaking change (changes that would cause existing functionality to not work as expected)
- [ ] Documentation update (updates to documentation, no changes to code)
- [ ] Other (please describe):

### Compliance and Security

<sup>_Ensure your changes adhere to project policies and do not introduce security vulnerabilities._</sup>

- [x] I have read and understood the [Clariti's VCS Policies](https://claritisoftware.atlassian.net/wiki/spaces/P2/pages/2756018262/CENG-3+Version+Control+System+VCS+Security+and+Compliance+Policy).
- [x] My commits are GPG-signed, adhering to project standards.
- [x] My code follows Clariti's coding standards and passes all existing lint/unit tests.
- [x] My changes do not introduce any new security issues.
- [x] I have performed a self-review to ensure the code introduces no new security vulnerabilities.
- [ ] I have addressed existing security issues in my code (if applicable).

### Testing and Documentation

<sup>_Confirm that your changes are well-tested and documented for future reference._</sup>

- [ ] I have added tests to cover my changes and ensure functionality.
- [ ] Necessary documentation has been added or updated.
- [ ] Dependent changes have been merged and published in downstream modules (if applicable).
- [ ] Any changes to global API methods have been documented.

## Additional Checklist

<sup>_Before merging, ensure all items are checked off (if applicable) to guarantee code quality and functionality._</sup>

- [ ] Next release publish via CI validates the fix end-to-end

## Additional Comments

<sup>_If your changes are large or complex, provide additional context. Discuss why you chose the solution you did and what alternatives were considered. Utilize visual aids like Loom for complex explanations._</sup>

Single-line change to `.github/workflows/release.yml` - SHA-pinned to `a892a5a61159132606e93a2fa6f4358831b04d26` (v1.14.2). Pinning hatchling to an older version was considered but ruled out as ineffective - `hatch build` creates an isolated build environment from `[build-system] requires` in `pyproject.toml`, so a system-level pin has no effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process to use a newer release action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->